### PR TITLE
Release version 1.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ofs-users/proxy",
-    "version": "1.21.0",
+    "version": "1.22.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ofs-users/proxy",
-            "version": "1.21.0",
+            "version": "1.22.0",
             "license": "UPL-1.0",
             "dependencies": {
                 "@ofs-users/proxy": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     ],
     "name": "@ofs-users/proxy",
     "type": "module",
-    "version": "1.21.0",
+    "version": "1.22.0",
     "description": "A Javascript proxy to access Oracle Field Service via REST API",
     "main": "dist/ofs.es.js",
     "module": "dist/ofs.es.js",


### PR DESCRIPTION
## Summary
Release version 1.22.0 to replace deprecated versions 1.21.0 and 1.21.1.

This is a clean release without the problematic enhancements from the 1.21.x versions.

## Changes
- Update package version to 1.22.0

Resolves #59