### PR TITLE
feat: add OJET/AMD compatibility and assistants dateTo support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ofs-users/proxy",
-    "version": "1.28.0",
+    "version": "1.29.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ofs-users/proxy",
-            "version": "1.28.0",
+            "version": "1.29.0",
             "license": "UPL-1.0",
             "dependencies": {
                 "@ofs-users/proxy": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,15 @@
     "description": "A Javascript proxy to access Oracle Field Service via REST API",
     "main": "dist/ofs.es.js",
     "module": "dist/ofs.es.js",
+    "exports": {
+        ".": {
+            "types": "./dist/OFS.d.ts",
+            "default": "./dist/ofs.es.js"
+        },
+        "./amd": {
+            "default": "./dist/ofs.amd.js"
+        }
+    },
     "types": "dist/OFS.d.ts",
     "repository": {
         "url": "git+https://github.com/oracle-samples/ofs-proxy-js.git"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     ],
     "name": "@ofs-users/proxy",
     "type": "module",
-    "version": "1.28.0",
+    "version": "1.29.0",
     "description": "A Javascript proxy to access Oracle Field Service via REST API",
     "main": "dist/ofs.es.js",
     "module": "dist/ofs.es.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -9,11 +9,18 @@ import dts from "rollup-plugin-dts";
 const config = [
     {
         input: "src/OFS.ts",
-        output: {
-            name: "OFS",
-            file: "dist/ofs.es.js",
-            format: "es",
-        },
+        output: [
+            {
+                name: "OFS",
+                file: "dist/ofs.es.js",
+                format: "es",
+            },
+            {
+                name: "OFS",
+                file: "dist/ofs.amd.js",
+                format: "amd",
+            },
+        ],
         plugins: [
             typescript(),
             terser({

--- a/src/OFS.ts
+++ b/src/OFS.ts
@@ -772,6 +772,9 @@ export class OFS {
         const queryParams: any = {};
         queryParams.dateFrom =
             params.dateFrom || new Date().toISOString().split('T')[0];
+        if (params.dateTo !== undefined) {
+            queryParams.dateTo = params.dateTo;
+        }
 
         if (params.expand && params.expand.length > 0) {
             queryParams.expand = params.expand.join(',');
@@ -808,6 +811,9 @@ export class OFS {
         const queryParams: any = {};
         queryParams.dateFrom =
             params.dateFrom || new Date().toISOString().split('T')[0];
+        if (params.dateTo !== undefined) {
+            queryParams.dateTo = params.dateTo;
+        }
 
         if (params.expand && params.expand.length > 0) {
             queryParams.expand = params.expand.join(',');

--- a/src/model.ts
+++ b/src/model.ts
@@ -357,6 +357,7 @@ export interface OFSGetResourceParams {
 
 export interface OFSGetResourceAssistantsParams {
     dateFrom?: string;
+    dateTo?: string;
     expand?: string[];
     fields?: string[];
     limit?: number;

--- a/test/general/compatibility.test.ts
+++ b/test/general/compatibility.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2022, 2023, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License (UPL), Version 1.0  as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+import { readFileSync } from "fs";
+import { OFS } from "../../src/OFS";
+
+describe("Backward compatibility and OJET/AMD compatibility", () => {
+    test("package metadata keeps ESM default and exposes AMD subpath", () => {
+        const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+
+        expect(packageJson.main).toBe("dist/ofs.es.js");
+        expect(packageJson.module).toBe("dist/ofs.es.js");
+
+        expect(packageJson.exports["."].default).toBe("./dist/ofs.es.js");
+        expect(packageJson.exports["."].types).toBe("./dist/OFS.d.ts");
+        expect(packageJson.exports["./amd"].default).toBe(
+            "./dist/ofs.amd.js"
+        );
+    });
+
+    test("rollup config includes AMD output artifact", () => {
+        const rollupConfig = readFileSync("rollup.config.mjs", "utf8");
+
+        expect(rollupConfig).toContain('file: "dist/ofs.amd.js"');
+        expect(rollupConfig).toContain('format: "amd"');
+    });
+
+    test("getResourceAssistants keeps default dateFrom behavior", async () => {
+        const proxy = new OFS({
+            instance: "example",
+            clientId: "client",
+            clientSecret: "secret",
+        });
+
+        const getMock = jest
+            .spyOn(proxy as any, "_get")
+            .mockResolvedValue({ status: 200, data: { items: [] } } as any);
+
+        await proxy.getResourceAssistants("resource-1");
+
+        expect(getMock).toHaveBeenCalled();
+        const [, queryParams] = getMock.mock.calls[0] as any[];
+        expect(queryParams.dateFrom).toBeDefined();
+    });
+
+    test("getResourceAssistants/getAllResourceAssistants pass dateTo when provided", async () => {
+        const proxy = new OFS({
+            instance: "example",
+            clientId: "client",
+            clientSecret: "secret",
+        });
+
+        const getMock = jest
+            .spyOn(proxy as any, "_get")
+            .mockResolvedValue({ status: 200, data: { items: [] } } as any);
+
+        await proxy.getResourceAssistants("resource-1", {
+            dateFrom: "2026-01-01",
+            dateTo: "2026-01-31",
+        });
+
+        const [, assistantsQueryParams] = getMock.mock.calls[0] as any[];
+        expect(assistantsQueryParams.dateTo).toBe("2026-01-31");
+
+        getMock.mockClear();
+
+        await proxy.getAllResourceAssistants("resource-1", {
+            dateFrom: "2026-01-01",
+            dateTo: "2026-01-31",
+        });
+
+        const [, allAssistantsQueryParams] = getMock.mock.calls[0] as any[];
+        expect(allAssistantsQueryParams.dateTo).toBe("2026-01-31");
+    });
+});


### PR DESCRIPTION
## Summary
- add AMD distribution output () alongside existing ESM output
- keep ESM default behavior and add  subpath export for OJET/AMD consumers
- add optional  support to resource assistants params and request query building
- add compatibility tests for backward compatibility and AMD/OJET packaging behavior

## Validation
- ran compatibility tests: 
> @ofs-users/proxy@1.29.0 test
> jest --runInBand test/general/compatibility.test.ts

----------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                                            
----------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------
All files |      16 |     16.5 |       7 |   16.03 |                                                                                                              
 OFS.ts   |   13.26 |     16.9 |    8.97 |   13.29 | 53,62,73,77,95-758,780,783,786,789,819,822,839,846,850,859,871-1113                                          
 model.ts |   30.13 |        0 |       0 |   30.13 | 52-69,74,152-155,158-163,166-169,172,180,193,206,213,225,229,258-270,289-311,344,368,386,420,448,484,560,644 
----------|---------|----------|---------|---------|-------------------------------------------------------------------------------------------------------------- (pass)
- ran dist build: 
> @ofs-users/proxy@1.29.0 dist
> rollup --config rollup.config.mjs (success)

Fixes #77