### PR TITLE
Add OFS metadata forms APIs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,28 @@
 ## Functions implemented
 
-| Function | URL |
-| ---------| ----------- |
-| `getActivities`| https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-get.html |
-| `createActivity`| https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-post.html |
-| `deleteActivity`| https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-delete.html |
-| `getActivityDetails`| https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-get.html |
-| `setFileProperty`|https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-propertylabel-put.html |
-| `getFileProperty`| https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-propertylabel-get.html | 
-| `updateActivity`| https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-patch.html
-| `getSubscriptions` | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-events-subscriptions-get.html
-| `importPlugins` | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-plugins-custom-actions-import-post.html
-| `getProperties` | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-get.html
-| `getPropertyDetails` | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-label-get.html
-| `updateProperty` | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-label-patch.html
-| `createReplaceProperty` | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-label-put.html
+| Function                | URL                                                                                                                        |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `getActivities`         | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-get.html                          |
+| `createActivity`        | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-post.html                         |
+| `deleteActivity`        | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-delete.html            |
+| `getActivityDetails`    | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-get.html               |
+| `setFileProperty`       | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-propertylabel-put.html |
+| `getFileProperty`       | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-propertylabel-get.html |
+| `updateActivity`        | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-patch.html             |
+| `getSubscriptions`      | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-events-subscriptions-get.html                |
+| `importPlugins`         | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-plugins-custom-actions-import-post.html  |
+| `getForms`              | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-forms-get.html                           |
+| `getProperties`         | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-get.html                      |
+| `getFormDetails`        | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-forms-label-get.html                     |
+| `getPropertyDetails`    | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-label-get.html                |
+| `updateProperty`        | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-label-patch.html              |
+| `createReplaceProperty` | https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofscmetadata-v1-properties-label-put.html                |
 
 ## Sample
 
 1. Generate the javascript version of the module (`npm run dist`). A new folder called `dist` will be created, containing a javascript module (`ofs.es.js`)
 2. Create in the same folder as the sample a file called `credentials_sample.json` with the following content, replacing the placeholders by your own environment data:
+
 ```
 {
     "instance": "<YOUR OFS INSTANCE NAME>",
@@ -27,7 +30,9 @@
     "clientSecret": "<YOUR APPLICATION CLIENT SECRET>"
 }
 ```
+
 3. Run the sample. The output should be a list of the active event subscriptions in your environment
+
 ```
 node sample.js
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ofs-users/proxy",
-    "version": "1.28.0",
+    "version": "1.29.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ofs-users/proxy",
-            "version": "1.28.0",
+            "version": "1.29.0",
             "license": "UPL-1.0",
             "dependencies": {
                 "@ofs-users/proxy": "^1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ofs-users/proxy",
-    "version": "1.29.0",
+    "version": "1.30.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ofs-users/proxy",
-            "version": "1.29.0",
+            "version": "1.30.0",
             "license": "UPL-1.0",
             "dependencies": {
                 "@ofs-users/proxy": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     ],
     "name": "@ofs-users/proxy",
     "type": "module",
-    "version": "1.28.0",
+    "version": "1.29.0",
     "description": "A Javascript proxy to access Oracle Field Service via REST API",
     "main": "dist/ofs.es.js",
     "module": "dist/ofs.es.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     ],
     "name": "@ofs-users/proxy",
     "type": "module",
-    "version": "1.29.0",
+    "version": "1.30.0",
     "description": "A Javascript proxy to access Oracle Field Service via REST API",
     "main": "dist/ofs.es.js",
     "module": "dist/ofs.es.js",

--- a/src/OFS.ts
+++ b/src/OFS.ts
@@ -5,1105 +5,1131 @@
 
 import { PathLike, readFileSync } from "fs";
 import {
-    OFSActivityResponse,
-    OFSCredentials,
-    OFSPropertyDetailsResponse,
-    OFSResponse,
-    OFSSubscriptionResponse,
-    OFSPropertyDetails,
-    OFSPropertyListResponse,
-    OFSGetPropertiesParams,
-    OFSTimeslotsResponse,
-    OFSGetActivitiesParams,
-    OFSSearchForActivitiesParams,
-    OFSBulkUpdateRequest,
-    OFSGetResourcesParams,
-    OFSGetResourceParams,
-    OFSGetResourceAssistantsParams,
-    OFSResourceResponse,
-    OFSSingleResourceResponse,
-    OFSResourceAssistantsResponse,
-    OFSResourceRoutesResponse,
-    OFSGetLastKnownPositionsParams,
-    OFSLastKnownPositionsResponse,
-    OFSGetSubmittedFormsParams,
-    OFSSubmittedFormsResponse,
-    OFSActivityLinkTypeResponse,
-    OFSLinkTemplatesResponse,
-    OFSShowBookingGridParams,
-    OFSShowBookingGridResponse,
-    OFSGetActivityBookingOptionsParams,
-    OFSGetActivityBookingOptionsResponse,
+  OFSActivityResponse,
+  OFSCredentials,
+  OFSFormDetailsResponse,
+  OFSFormsResponse,
+  OFSPropertyDetailsResponse,
+  OFSResponse,
+  OFSSubscriptionResponse,
+  OFSGetFormDetailsParams,
+  OFSGetFormsParams,
+  OFSPropertyDetails,
+  OFSPropertyListResponse,
+  OFSGetPropertiesParams,
+  OFSTimeslotsResponse,
+  OFSGetActivitiesParams,
+  OFSSearchForActivitiesParams,
+  OFSBulkUpdateRequest,
+  OFSGetResourcesParams,
+  OFSGetResourceParams,
+  OFSGetResourceAssistantsParams,
+  OFSResourceResponse,
+  OFSSingleResourceResponse,
+  OFSResourceAssistantsResponse,
+  OFSResourceRoutesResponse,
+  OFSGetLastKnownPositionsParams,
+  OFSLastKnownPositionsResponse,
+  OFSGetSubmittedFormsParams,
+  OFSSubmittedFormsResponse,
+  OFSActivityLinkTypeResponse,
+  OFSLinkTemplatesResponse,
+  OFSShowBookingGridParams,
+  OFSShowBookingGridResponse,
+  OFSGetActivityBookingOptionsParams,
+  OFSGetActivityBookingOptionsResponse,
 } from "./model";
 
 export * from "./model";
 export class OFS {
-    private _credentials!: OFSCredentials;
-    private _hash!: string;
-    private _baseURL!: URL;
-    private static DEFAULT_DOMAIN = "fs.ocs.oraclecloud.com";
+  private _credentials!: OFSCredentials;
+  private _hash!: string;
+  private _baseURL!: URL;
+  private static DEFAULT_DOMAIN = "fs.ocs.oraclecloud.com";
 
-    public get credentials(): OFSCredentials {
-        return this._credentials;
+  public get credentials(): OFSCredentials {
+    return this._credentials;
+  }
+  public set credentials(v: OFSCredentials) {
+    this._credentials = v;
+    this._hash = OFS.authenticateUser(v);
+    if ("baseURL" in v && v.baseURL != "") {
+      this._baseURL = new URL(v.baseURL!);
+    } else {
+      this._baseURL = new URL(`https://${this.instance}.${OFS.DEFAULT_DOMAIN}`);
     }
-    public set credentials(v: OFSCredentials) {
-        this._credentials = v;
-        this._hash = OFS.authenticateUser(v);
-        if ("baseURL" in v && v.baseURL != "") {
-            this._baseURL = new URL(v.baseURL!);
+  }
+
+  public get authorization(): string {
+    return this._hash;
+  }
+
+  constructor(credentials: OFSCredentials) {
+    this.credentials = credentials;
+  }
+
+  public get instance(): string {
+    return this.credentials.instance || "";
+  }
+  public get baseURL(): URL {
+    return this._baseURL || "";
+  }
+  private static authenticateUser(credentials: OFSCredentials): string {
+    if ("token" in credentials && credentials.token != "") {
+      return "Bearer " + credentials.token;
+    } else {
+      var token =
+        credentials.clientId +
+        "@" +
+        credentials.instance +
+        ":" +
+        credentials.clientSecret;
+      var hash = Buffer.from(token).toString("base64");
+      return "Basic " + hash;
+    }
+  }
+
+  private _get(
+    partialURL: string,
+    params: any = undefined,
+    extraHeaders: Headers = new Headers()
+  ): Promise<OFSResponse> {
+    var theURL = new URL(partialURL, this._baseURL);
+    if (params != undefined) {
+      const urlSearchParams = new URLSearchParams(params);
+      theURL.search = urlSearchParams.toString();
+    }
+    var myHeaders = new Headers();
+    myHeaders.append("Authorization", this.authorization);
+    extraHeaders.forEach((value, key) => {
+      myHeaders.append(key, value);
+    });
+    var requestOptions = {
+      method: "GET",
+      headers: myHeaders,
+    };
+    const fetchPromise = fetch(theURL, requestOptions)
+      .then(async function (response) {
+        // Your code for handling the data you get from the API
+        if (response.status < 400) {
+          var data;
+          if (response.headers.get("Content-Type")?.includes("json")) {
+            data = await response.json();
+          } else if (response.headers.get("Content-Type")?.includes("text")) {
+            data = await response.text();
+          } else {
+            data = await response.blob();
+          }
+          return new OFSResponse(
+            theURL,
+            response.status,
+            undefined,
+            data,
+            response.headers.get("Content-Type") || undefined
+          );
         } else {
-            this._baseURL = new URL(
-                `https://${this.instance}.${OFS.DEFAULT_DOMAIN}`
-            );
-        }
-    }
-
-    public get authorization(): string {
-        return this._hash;
-    }
-
-    constructor(credentials: OFSCredentials) {
-        this.credentials = credentials;
-    }
-
-    public get instance(): string {
-        return this.credentials.instance || "";
-    }
-    public get baseURL(): URL {
-        return this._baseURL || "";
-    }
-    private static authenticateUser(credentials: OFSCredentials): string {
-        if ("token" in credentials && credentials.token != "") {
-            return "Bearer " + credentials.token;
-        } else {
-            var token =
-                credentials.clientId +
-                "@" +
-                credentials.instance +
-                ":" +
-                credentials.clientSecret;
-            var hash = Buffer.from(token).toString("base64");
-            return "Basic " + hash;
-        }
-    }
-
-    private _get(
-        partialURL: string,
-        params: any = undefined,
-        extraHeaders: Headers = new Headers()
-    ): Promise<OFSResponse> {
-        var theURL = new URL(partialURL, this._baseURL);
-        if (params != undefined) {
-            const urlSearchParams = new URLSearchParams(params);
-            theURL.search = urlSearchParams.toString();
-        }
-        var myHeaders = new Headers();
-        myHeaders.append("Authorization", this.authorization);
-        extraHeaders.forEach((value, key) => {
-            myHeaders.append(key, value);
-        });
-        var requestOptions = {
-            method: "GET",
-            headers: myHeaders,
-        };
-        const fetchPromise = fetch(theURL, requestOptions)
-            .then(async function (response) {
-                // Your code for handling the data you get from the API
-                if (response.status < 400) {
-                    var data;
-                    if (
-                        response.headers.get("Content-Type")?.includes("json")
-                    ) {
-                        data = await response.json();
-                    } else if (
-                        response.headers.get("Content-Type")?.includes("text")
-                    ) {
-                        data = await response.text();
-                    } else {
-                        data = await response.blob();
-                    }
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        undefined,
-                        data,
-                        response.headers.get("Content-Type") || undefined
-                    );
-                } else {
-                    try {
-                        var data;
-                        if (
-                            response.headers
-                                .get("Content-Type")
-                                ?.includes("json")
-                        ) {
-                            data = await response.json();
-                        } else if (
-                            response.headers
-                                .get("Content-Type")
-                                ?.includes("text")
-                        ) {
-                            data = await response.text();
-                        } else {
-                            data = await response.blob();
-                        }
-                        return new OFSResponse(
-                            theURL,
-                            response.status,
-                            undefined,
-                            data,
-                            response.headers.get("Content-Type") || undefined
-                        );
-                    } catch (error) {
-                        console.log(
-                            "error trying to capture the response with status >400",
-                            error
-                        );
-                        return new OFSResponse(
-                            theURL,
-                            response.status,
-                            response.statusText,
-                            undefined
-                        );
-                    }
-                }
-            })
-            .catch((error) => {
-                console.log("error", error);
-                return new OFSResponse(theURL, -1);
-            });
-        return fetchPromise;
-    }
-
-    private _patch(partialURL: string, data: any): Promise<OFSResponse> {
-        var theURL = new URL(partialURL, this._baseURL);
-        var myHeaders = new Headers();
-        myHeaders.append("Authorization", this.authorization);
-        myHeaders.append("Content-Type", "application/json");
-        var requestOptions: RequestInit = {
-            method: "PATCH",
-            headers: myHeaders,
-            body: JSON.stringify(data),
-        };
-        const fetchPromise = fetch(theURL, requestOptions)
-            .then(async function (response) {
-                // Your code for handling the data you get from the API
-                if (response.status < 400) {
-                    var data = await response.json();
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        undefined,
-                        data
-                    );
-                } else {
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        response.statusText,
-                        undefined
-                    );
-                }
-            })
-            .catch((error) => {
-                console.log("error", error);
-                return new OFSResponse(theURL, -1);
-            });
-        return fetchPromise;
-    }
-
-    private _put(
-        partialURL: string,
-        requestData: any,
-        contentType: string = "application/json",
-        fileName?: string
-    ): Promise<OFSResponse> {
-        var theURL = new URL(partialURL, this._baseURL);
-        var myHeaders = new Headers();
-        myHeaders.append("Authorization", this.authorization);
-        myHeaders.append("Content-Type", contentType);
-        if (contentType == "application/json") {
-            requestData = JSON.stringify(requestData);
-        }
-        if (fileName) {
-            myHeaders.append(
-                "Content-Disposition",
-                `attachment; filename=${fileName}`
-            );
-        }
-        var requestOptions: RequestInit = {
-            method: "PUT",
-            headers: myHeaders,
-            body: requestData,
-        };
-        const fetchPromise = fetch(theURL, requestOptions)
-            .then(async function (response) {
-                // Your code for handling the data you get from the API
-                if (response.status < 400) {
-                    if (response.status == 204) {
-                        //No data here
-                        return new OFSResponse(
-                            theURL,
-                            response.status,
-                            undefined,
-                            undefined
-                        );
-                    } else {
-                        var data = await response.json();
-                        return new OFSResponse(
-                            theURL,
-                            response.status,
-                            undefined,
-                            data
-                        );
-                    }
-                } else {
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        response.statusText,
-                        requestData
-                    );
-                }
-            })
-            .catch((error) => {
-                console.log("error", error);
-                return new OFSResponse(theURL, -1);
-            });
-        return fetchPromise;
-    }
-
-    private _post(partialURL: string, data: any): Promise<OFSResponse> {
-        var theURL = new URL(partialURL, this._baseURL);
-        var myHeaders = new Headers();
-        myHeaders.append("Authorization", this.authorization);
-        myHeaders.append("Content-Type", "application/json");
-        var requestOptions: RequestInit = {
-            method: "POST",
-            headers: myHeaders,
-            body: JSON.stringify(data),
-        };
-        const fetchPromise = fetch(theURL, requestOptions)
-            .then(async function (response) {
-                // Your code for handling the data you get from the API
-                if (response.status < 400) {
-                    var data = await response.json();
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        undefined,
-                        data
-                    );
-                } else {
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        response.statusText,
-                        await response.json()
-                    );
-                }
-            })
-            .catch((error) => {
-                console.log("error", error);
-                return new OFSResponse(theURL, -1);
-            });
-        return fetchPromise;
-    }
-
-    private _postMultiPart(
-        partialURL: string,
-        data: FormData
-    ): Promise<OFSResponse> {
-        var theURL = new URL(partialURL, this._baseURL);
-        var myHeaders = new Headers();
-        myHeaders.append("Authorization", this.authorization);
-        //myHeaders.append("Content-Type", "multipart/form-data");
-
-        var requestOptions: RequestInit = {
-            method: "POST",
-            headers: myHeaders,
-            body: data,
-        };
-        const fetchPromise = fetch(theURL, requestOptions)
-            .then(async function (response) {
-                // Your code for handling the data you get from the API
-                if (response.status < 400) {
-                    if (response.status == 204) {
-                        //No data here
-                        return new OFSResponse(
-                            theURL,
-                            response.status,
-                            undefined,
-                            undefined
-                        );
-                    } else {
-                        var data = await response.json();
-                        return new OFSResponse(
-                            theURL,
-                            response.status,
-                            undefined,
-                            data
-                        );
-                    }
-                } else {
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        response.statusText,
-                        undefined
-                    );
-                }
-            })
-            .catch((error) => {
-                console.log("error", error);
-                return new OFSResponse(theURL, -1);
-            });
-        return fetchPromise;
-    }
-
-    private _delete(partialURL: string): Promise<OFSResponse> {
-        var theURL = new URL(partialURL, this._baseURL);
-        var myHeaders = new Headers();
-        myHeaders.append("Authorization", this.authorization);
-        var requestOptions = {
-            method: "DELETE",
-            headers: myHeaders,
-        };
-        const fetchPromise = fetch(theURL, requestOptions)
-            .then(async function (response) {
-                // Your code for handling the data you get from the API
-                if (response.status == 204) {
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        undefined,
-                        undefined
-                    );
-                } else {
-                    return new OFSResponse(
-                        theURL,
-                        response.status,
-                        response.statusText,
-                        await response.json()
-                    );
-                }
-            })
-            .catch((error) => {
-                console.log("error", error);
-                return new OFSResponse(theURL, -1);
-            });
-        return fetchPromise;
-    }
-
-    // Core: Subscription Management
-    async getSubscriptions(
-        all: boolean = false
-    ): Promise<OFSSubscriptionResponse> {
-        const partialURL = "/rest/ofscCore/v1/events/subscriptions";
-        return this._get(partialURL, { allSubscriptions: all });
-    }
-
-    async createSubscription(data: any): Promise<OFSResponse> {
-        const partialURL = "/rest/ofscCore/v1/events/subscriptions/";
-        return this._post(partialURL, data);
-    }
-
-    async deleteSubscription(sid: string): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/events/subscriptions/${sid}`;
-        return this._delete(partialURL);
-    }
-
-    async getSubscriptionDetails(sid: string): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/events/subscriptions/${sid}`;
-        return this._get(partialURL);
-    }
-
-    // Core: Event Management
-    async getEvents(
-        sid: string,
-        page: string = "lastRequested",
-        since = null,
-        limit: number = 1000
-    ): Promise<OFSResponse> {
-        var params: {
-            subscriptionId: string;
-            page?: string;
-            limit: number;
-            since?: string | null;
-        } = {
-            subscriptionId: sid,
-            page: page,
-            limit: limit,
-            since: since,
-        };
-        if (since == null) {
-            delete params.since;
-        } else {
-            delete params.page;
-        }
-
-        const partialURL = "/rest/ofscCore/v1/events";
-        return this._get(partialURL, params);
-    }
-
-    // Core: Activity Management
-    async bulkUpdateActivity(data: OFSBulkUpdateRequest): Promise<OFSResponse> {
-        const partialURL =
-            "/rest/ofscCore/v1/activities/custom-actions/bulkUpdate";
-        return this._post(partialURL, data);
-    }
-    async createActivity(data: any): Promise<OFSResponse> {
-        const partialURL = "/rest/ofscCore/v1/activities";
-        return this._post(partialURL, data);
-    }
-
-    async deleteActivity(aid: number): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}`;
-        return this._delete(partialURL);
-    }
-
-    async getActivityDetails(aid: number): Promise<OFSActivityResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}`;
-        return this._get(partialURL);
-    }
-    /**
-     * Retrieve activities linked to an existing activity
-     * @param aid Activity id to retrieve linked activities for
-     */
-    async getLinkedActivities(aid: number): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}/linkedActivities`;
-        return this._get(partialURL);
-    }
-
-    /**
-     * Retrieve the link type between two activities
-     * @param aid Activity id
-     * @param linkedActivityId Linked activity id
-     * @param linkType Type of link to retrieve
-     */
-    async getActivityLinkType(aid: number, linkedActivityId: number, linkType: string): Promise<OFSActivityLinkTypeResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}/linkedActivities/${linkedActivityId}/linkTypes/${linkType}`;
-        return this._get(partialURL);
-    }
-    async updateActivity(aid: number, data: any): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}`;
-        return this._patch(partialURL, data);
-    }
-    async moveActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "move");
-    }
-    async delayActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "delay");
-    }
-    async reopenActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "reopen");
-    }
-    async startActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "start");
-    }
-    async suspendActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "suspend");
-    }
-    async completeActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "complete");
-    }
-    async stopTravel(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "stopTravel");
-    }
-    async cancelActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "cancel");
-    }
-    async startPrework(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "startPrework");
-    }
-    async enrouteActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "enroute");
-    }
-    async notDoneActivity(aid: number, data: any): Promise<OFSResponse> {
-        return this._executeActivityAction(aid, data, "notDone");
-    }
-    private async _executeActivityAction(
-        aid: number,
-        data: any,
-        action: any
-    ): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}/custom-actions/${action}`;
-        return this._post(partialURL, data);
-    }
-    async getActivityFilePropertyContent(
-        aid: number,
-        propertyLabel: string,
-        nediaType: string = "*/*"
-    ): Promise<OFSResponse> {
-        var myHeaders = new Headers();
-        myHeaders.append("Accept", nediaType);
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
-        return this._get(partialURL, undefined, myHeaders);
-    }
-
-    async getActivityFilePropertyMetadata(
-        aid: number,
-        propertyLabel: string
-    ): Promise<OFSResponse> {
-        var myHeaders = new Headers();
-        myHeaders.append("Accept", "*/*");
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
-        return this._get(partialURL, undefined, myHeaders);
-    }
-
-    async getActivityFileProperty(
-        aid: number,
-        propertyLabel: string
-    ): Promise<OFSResponse> {
-        var myHeaders = new Headers();
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
-        var metadata = await this.getActivityFilePropertyMetadata(
-            aid,
-            propertyLabel
-        );
-        if (metadata.status < 400) {
-            var contentType = metadata.contentType;
-            if (contentType) {
-                myHeaders.append("Accept", contentType);
+          try {
+            var data;
+            if (response.headers.get("Content-Type")?.includes("json")) {
+              data = await response.json();
+            } else if (response.headers.get("Content-Type")?.includes("text")) {
+              data = await response.text();
+            } else {
+              data = await response.blob();
             }
-            var content = this._get(partialURL, undefined, myHeaders);
             return new OFSResponse(
-                metadata.url,
-                metadata.status,
-                metadata.description,
-                {
-                    ...metadata.data,
-                    content: (await content).data,
-                },
-                metadata.contentType
+              theURL,
+              response.status,
+              undefined,
+              data,
+              response.headers.get("Content-Type") || undefined
             );
+          } catch (error) {
+            console.log(
+              "error trying to capture the response with status >400",
+              error
+            );
+            return new OFSResponse(
+              theURL,
+              response.status,
+              response.statusText,
+              undefined
+            );
+          }
+        }
+      })
+      .catch((error) => {
+        console.log("error", error);
+        return new OFSResponse(theURL, -1);
+      });
+    return fetchPromise;
+  }
+
+  private _patch(partialURL: string, data: any): Promise<OFSResponse> {
+    var theURL = new URL(partialURL, this._baseURL);
+    var myHeaders = new Headers();
+    myHeaders.append("Authorization", this.authorization);
+    myHeaders.append("Content-Type", "application/json");
+    var requestOptions: RequestInit = {
+      method: "PATCH",
+      headers: myHeaders,
+      body: JSON.stringify(data),
+    };
+    const fetchPromise = fetch(theURL, requestOptions)
+      .then(async function (response) {
+        // Your code for handling the data you get from the API
+        if (response.status < 400) {
+          var data = await response.json();
+          return new OFSResponse(theURL, response.status, undefined, data);
         } else {
-            return metadata;
+          return new OFSResponse(
+            theURL,
+            response.status,
+            response.statusText,
+            undefined
+          );
         }
+      })
+      .catch((error) => {
+        console.log("error", error);
+        return new OFSResponse(theURL, -1);
+      });
+    return fetchPromise;
+  }
+
+  private _put(
+    partialURL: string,
+    requestData: any,
+    contentType: string = "application/json",
+    fileName?: string
+  ): Promise<OFSResponse> {
+    var theURL = new URL(partialURL, this._baseURL);
+    var myHeaders = new Headers();
+    myHeaders.append("Authorization", this.authorization);
+    myHeaders.append("Content-Type", contentType);
+    if (contentType == "application/json") {
+      requestData = JSON.stringify(requestData);
     }
-
-    async setActivityFileProperty(
-        aid: number,
-        propertyLabel: string,
-        blob: Blob,
-        fileName: string,
-        contentType: string = "*/*"
-    ): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
-        return this._put(partialURL, blob, contentType, fileName);
+    if (fileName) {
+      myHeaders.append(
+        "Content-Disposition",
+        `attachment; filename=${fileName}`
+      );
     }
-
-    async getSubmittedForms(
-        activityId: number,
-        params: OFSGetSubmittedFormsParams = {}
-    ): Promise<OFSSubmittedFormsResponse> {
-        const partialURL = `/rest/ofscCore/v1/activities/${activityId}/submittedForms`;
-        const queryParams: any = {
-            scope: params.scope !== undefined ? params.scope : 'activity'
-        };
-
-        if (params.offset !== undefined) {
-            queryParams.offset = params.offset;
-        }
-        if (params.limit !== undefined) {
-            queryParams.limit = params.limit;
-        }
-
-        return this._get(partialURL, queryParams);
-    }
-
-    // Core: User Management
-    async getUsers(
-        offset: number = 0,
-        limit: number = 100
-    ): Promise<OFSResponse> {
-        const partialURL = "/rest/ofscCore/v1/users";
-        return this._get(partialURL, { offset: offset, limit: limit });
-    }
-
-    /**
-     * Retrieves all users from the OFS API.
-     * @returns An object containing all users.
-     */
-    async getAllUsers() {
-        const partialURL = "/rest/ofscCore/v1/users";
-        // Start with offset 0 and keep getting results until we get less than 100
-        var offset = 0;
-        var limit = 100;
-        var result: any = undefined;
-        var allResults: any = { totalResults: 0, items: [] };
-        do {
-            result = await this._get(partialURL, {
-                offset: offset,
-                limit: limit,
-            });
-            if (result.status < 400) {
-                if (allResults.totalResults == 0) {
-                    allResults = result.data;
-                } else {
-                    allResults.items = allResults.items.concat(
-                        result.data.items
-                    );
-                }
-                offset += limit;
-            } else {
-                return result;
-            }
-        } while (result.data.items.length == limit);
-        return allResults;
-    }
-
-    async getUserDetails(uname: string): Promise<OFSResponse> {
-        const partialURL = `/rest/ofscCore/v1/users/${uname}`;
-        return this._get(partialURL);
-    }
-
-    // Core: Resource Management
-    async getResources(
-        params: OFSGetResourcesParams = {}
-    ): Promise<OFSResourceResponse> {
-        const partialURL = "/rest/ofscCore/v1/resources";
-        const queryParams: any = {};
-        
-        if (params.canBeTeamHolder !== undefined) {
-            queryParams.canBeTeamHolder = params.canBeTeamHolder;
-        }
-        if (params.canParticipateInTeam !== undefined) {
-            queryParams.canParticipateInTeam = params.canParticipateInTeam;
-        }
-        if (params.expand && params.expand.length > 0) {
-            queryParams.expand = params.expand.join(',');
-        }
-        if (params.fields && params.fields.length > 0) {
-            queryParams.fields = params.fields.join(',');
-        }
-        if (params.limit !== undefined) {
-            queryParams.limit = params.limit;
-        }
-        if (params.offset !== undefined) {
-            queryParams.offset = params.offset;
-        }
-
-        return this._get(partialURL, queryParams);
-    }
-
-    /**
-     * Retrieves all resources from the OFS API.
-     * @param params Optional parameters for filtering resources
-     * @returns An object containing all resources.
-     */
-    async getAllResources(params: Omit<OFSGetResourcesParams, 'limit' | 'offset'> = {}) {
-        const partialURL = "/rest/ofscCore/v1/resources";
-        var offset = 0;
-        var limit = 100;
-        var result: any = undefined;
-        var allResults: any = { totalResults: 0, items: [] };
-        
-        const queryParams: any = {};
-        if (params.canBeTeamHolder !== undefined) {
-            queryParams.canBeTeamHolder = params.canBeTeamHolder;
-        }
-        if (params.canParticipateInTeam !== undefined) {
-            queryParams.canParticipateInTeam = params.canParticipateInTeam;
-        }
-        if (params.expand && params.expand.length > 0) {
-            queryParams.expand = params.expand.join(',');
-        }
-        if (params.fields && params.fields.length > 0) {
-            queryParams.fields = params.fields.join(',');
-        }
-
-        do {
-            result = await this._get(partialURL, {
-                ...queryParams,
-                offset: offset,
-                limit: limit,
-            });
-            if (result.status < 400) {
-                if (allResults.totalResults == 0) {
-                    allResults = result.data;
-                } else {
-                    allResults.items = allResults.items.concat(
-                        result.data.items
-                    );
-                }
-                offset += limit;
-            } else {
-                return result;
-            }
-        } while (result.data.items.length == limit);
-        return allResults;
-    }
-
-    /**
-     * Retrieves a single resource by ID from the OFS API.
-     * @param resourceId The ID of the resource to retrieve
-     * @param params Optional parameters for expanding or filtering fields
-     * @returns The resource details
-     */
-    async getResource(
-        resourceId: string,
-        params: OFSGetResourceParams = {}
-    ): Promise<OFSSingleResourceResponse> {
-        const partialURL = `/rest/ofscCore/v1/resources/${resourceId}`;
-        const queryParams: any = {};
-
-        if (params.expand && params.expand.length > 0) {
-            queryParams.expand = params.expand.join(',');
-        }
-        if (params.fields && params.fields.length > 0) {
-            queryParams.fields = params.fields.join(',');
-        }
-
-        return this._get(partialURL, Object.keys(queryParams).length > 0 ? queryParams : undefined);
-    }
-
-    /**
-     * Retrieves assistants for a given resource.
-     * @param resourceId The ID of the resource
-     * @param params Optional parameters for expanding/filtering fields and pagination
-     * @returns A paginated list of assistants for the resource
-     */
-    async getResourceAssistants(
-        resourceId: string,
-        params: OFSGetResourceAssistantsParams = {}
-    ): Promise<OFSResourceAssistantsResponse> {
-        const partialURL = `/rest/ofscCore/v1/resources/${resourceId}/assistants`;
-        const queryParams: any = {};
-        queryParams.dateFrom =
-            params.dateFrom || new Date().toISOString().split('T')[0];
-
-        if (params.expand && params.expand.length > 0) {
-            queryParams.expand = params.expand.join(',');
-        }
-        if (params.fields && params.fields.length > 0) {
-            queryParams.fields = params.fields.join(',');
-        }
-        if (params.limit !== undefined) {
-            queryParams.limit = params.limit;
-        }
-        if (params.offset !== undefined) {
-            queryParams.offset = params.offset;
-        }
-
-        return this._get(partialURL, Object.keys(queryParams).length > 0 ? queryParams : undefined);
-    }
-
-    /**
-     * Retrieves all assistants for a given resource using pagination.
-     * @param resourceId The ID of the resource
-     * @param params Optional parameters for expanding/filtering fields (excludes pagination)
-     * @returns An object containing all assistants for the resource
-     */
-    async getAllResourceAssistants(
-        resourceId: string,
-        params: Omit<OFSGetResourceAssistantsParams, 'limit' | 'offset'> = {}
-    ) {
-        const partialURL = `/rest/ofscCore/v1/resources/${resourceId}/assistants`;
-        var offset = 0;
-        var limit = 100;
-        var result: any = undefined;
-        var allResults: any = { totalResults: 0, items: [] };
-
-        const queryParams: any = {};
-        queryParams.dateFrom =
-            params.dateFrom || new Date().toISOString().split('T')[0];
-
-        if (params.expand && params.expand.length > 0) {
-            queryParams.expand = params.expand.join(',');
-        }
-        if (params.fields && params.fields.length > 0) {
-            queryParams.fields = params.fields.join(',');
-        }
-
-        do {
-            result = await this._get(partialURL, {
-                ...queryParams,
-                offset: offset,
-                limit: limit,
-            });
-
-            if (result.status < 400) {
-                const pageItems = Array.isArray(result.data)
-                    ? result.data
-                    : result.data?.items || [];
-
-                if (allResults.totalResults == 0) {
-                    if (Array.isArray(result.data)) {
-                        allResults = { totalResults: 0, items: [] };
-                    } else {
-                        allResults = result.data;
-                    }
-                }
-
-                if (allResults.items === undefined) {
-                    allResults.items = [];
-                }
-
-                if (allResults.totalResults === 0 && allResults.items.length === 0) {
-                    allResults.items = pageItems;
-                } else {
-                    allResults.items = allResults.items.concat(pageItems);
-                }
-
-                allResults.totalResults = allResults.items.length;
-
-                offset += limit;
-            } else {
-                return result;
-            }
-        } while ((Array.isArray(result.data) ? result.data.length : result.data?.items?.length || 0) == limit);
-
-        return allResults;
-    }
-
-    async getResourceRoutes(
-        resourceId: string,
-        date: string,
-        activityFields?: string[]
-    ): Promise<OFSResourceRoutesResponse> {
-        const partialURL = `/rest/ofscCore/v1/resources/${resourceId}/routes/${date}`;
-        const queryParams: any = {};
-        
-        if (activityFields && activityFields.length > 0) {
-            queryParams.activityFields = activityFields.join(',');
-        }
-
-        return this._get(partialURL, queryParams);
-    }
-
-    async getLastKnownPositions(
-        params: OFSGetLastKnownPositionsParams = {}
-    ): Promise<OFSLastKnownPositionsResponse> {
-        const partialURL = "/rest/ofscCore/v1/resources/custom-actions/lastKnownPositions";
-        const queryParams: any = {};
-        
-        if (params.offset !== undefined) {
-            queryParams.offset = params.offset;
-        }
-        if (params.resources && params.resources.length > 0) {
-            queryParams.resources = params.resources.join(',');
-        }
-
-        return this._get(partialURL, queryParams);
-    }
-
-    /**
-     * Retrieves all last known positions from the OFS API using pagination.
-     * @param params Optional parameters for filtering resources (excludes offset)
-     * @returns An object containing all last known positions.
-     */
-    async getAllLastKnownPositions(
-        params: Omit<OFSGetLastKnownPositionsParams, 'offset'> = {}
-    ) {
-        const partialURL = "/rest/ofscCore/v1/resources/custom-actions/lastKnownPositions";
-        var offset = 0;
-        var result: any = undefined;
-        var allResults: any = { totalResults: 0, items: [] };
-        
-        const queryParams: any = {};
-        if (params.resources && params.resources.length > 0) {
-            queryParams.resources = params.resources.join(',');
-        }
-
-        do {
-            result = await this._get(partialURL, {
-                ...queryParams,
-                offset: offset,
-            });
-            if (result.status < 400) {
-                if (allResults.totalResults == 0) {
-                    allResults = result.data;
-                } else {
-                    allResults.items = allResults.items.concat(
-                        result.data.items
-                    );
-                }
-                // Update the total count to reflect actual accumulated items
-                allResults.totalResults = allResults.items.length;
-                
-                // Increment offset by the number of items returned
-                offset += result.data.items.length;
-            } else {
-                return result;
-            }
-        } while (result.data.hasMore === true);
-        
-        return allResults;
-    }
-
-    // Core: Activities Management
-    async getActivities(
-        params: OFSGetActivitiesParams,
-        offset: number = 0,
-        limit: number = 100
-    ): Promise<OFSResponse> {
-        const partialURL = "/rest/ofscCore/v1/activities";
-        return this._get(partialURL, {
-            ...params,
-            offset: offset,
-            limit: limit,
-        });
-    }
-
-    // Core: Activities Management
-    async searchForActivities(
-        params: OFSSearchForActivitiesParams,
-        offset: number = 0,
-        limit: number = 100
-    ): Promise<OFSResponse> {
-        const partialURL = "/rest/ofscCore/v1/activities/custom-actions/search";
-        return this._get(partialURL, {
-            ...params,
-            offset: offset,
-            limit: limit,
-        });
-    }
-    /**
-     * Retrieves all activities from the OFS API.
-     * @returns An object containing all activities.
-     */
-    async getAllActivities(
-        params: OFSGetActivitiesParams,
-        limit: number = 1000
-    ) {
-        const partialURL = "/rest/ofscCore/v1/activities";
-        // Start with offset 0 and keep getting results until we get less than 100
-        var offset = 0;
-
-        var result: any = undefined;
-        var allResults: any = {
-            status: 200,
-            detail: "",
-            title: "",
-            totalResults: 0,
-            items: [],
-        };
-        do {
-            result = await this._get(partialURL, {
-                ...params,
-                offset: offset,
-                limit: limit,
-            });
-            if (result.status == 200) {
-                if (allResults.totalResults == 0) {
-                    allResults = result.data;
-                    allResults.status = 200;
-                } else {
-                    allResults.items = allResults.items.concat(
-                        result.data.items
-                    );
-                }
-                allResults.totalResults = allResults.items.length;
-                offset += limit;
-            } else {
-                return result;
-            }
-        } while (result.data.hasMore == true);
-        return allResults;
-    }
-    // Metadata: Plugin Management
-    async importPlugins(file?: PathLike, data?: string): Promise<OFSResponse> {
-        const partialURL =
-            "/rest/ofscMetadata/v1/plugins/custom-actions/import";
-        var formData = new FormData();
-        if (file) {
-            var blob = new Blob([readFileSync(file)], { type: "text/xml" });
-
-            formData.append("pluginFile", blob, file.toString());
-        } else if (data) {
-            var blob = new Blob([data], { type: "text/xml" });
-            formData.append("pluginFile", blob, "plugin.xml");
+    var requestOptions: RequestInit = {
+      method: "PUT",
+      headers: myHeaders,
+      body: requestData,
+    };
+    const fetchPromise = fetch(theURL, requestOptions)
+      .then(async function (response) {
+        // Your code for handling the data you get from the API
+        if (response.status < 400) {
+          if (response.status == 204) {
+            //No data here
+            return new OFSResponse(
+              theURL,
+              response.status,
+              undefined,
+              undefined
+            );
+          } else {
+            var data = await response.json();
+            return new OFSResponse(theURL, response.status, undefined, data);
+          }
         } else {
-            throw "Must provide file or data";
+          return new OFSResponse(
+            theURL,
+            response.status,
+            response.statusText,
+            requestData
+          );
+        }
+      })
+      .catch((error) => {
+        console.log("error", error);
+        return new OFSResponse(theURL, -1);
+      });
+    return fetchPromise;
+  }
+
+  private _post(partialURL: string, data: any): Promise<OFSResponse> {
+    var theURL = new URL(partialURL, this._baseURL);
+    var myHeaders = new Headers();
+    myHeaders.append("Authorization", this.authorization);
+    myHeaders.append("Content-Type", "application/json");
+    var requestOptions: RequestInit = {
+      method: "POST",
+      headers: myHeaders,
+      body: JSON.stringify(data),
+    };
+    const fetchPromise = fetch(theURL, requestOptions)
+      .then(async function (response) {
+        // Your code for handling the data you get from the API
+        if (response.status < 400) {
+          var data = await response.json();
+          return new OFSResponse(theURL, response.status, undefined, data);
+        } else {
+          return new OFSResponse(
+            theURL,
+            response.status,
+            response.statusText,
+            await response.json()
+          );
+        }
+      })
+      .catch((error) => {
+        console.log("error", error);
+        return new OFSResponse(theURL, -1);
+      });
+    return fetchPromise;
+  }
+
+  private _postMultiPart(
+    partialURL: string,
+    data: FormData
+  ): Promise<OFSResponse> {
+    var theURL = new URL(partialURL, this._baseURL);
+    var myHeaders = new Headers();
+    myHeaders.append("Authorization", this.authorization);
+    //myHeaders.append("Content-Type", "multipart/form-data");
+
+    var requestOptions: RequestInit = {
+      method: "POST",
+      headers: myHeaders,
+      body: data,
+    };
+    const fetchPromise = fetch(theURL, requestOptions)
+      .then(async function (response) {
+        // Your code for handling the data you get from the API
+        if (response.status < 400) {
+          if (response.status == 204) {
+            //No data here
+            return new OFSResponse(
+              theURL,
+              response.status,
+              undefined,
+              undefined
+            );
+          } else {
+            var data = await response.json();
+            return new OFSResponse(theURL, response.status, undefined, data);
+          }
+        } else {
+          return new OFSResponse(
+            theURL,
+            response.status,
+            response.statusText,
+            undefined
+          );
+        }
+      })
+      .catch((error) => {
+        console.log("error", error);
+        return new OFSResponse(theURL, -1);
+      });
+    return fetchPromise;
+  }
+
+  private _delete(partialURL: string): Promise<OFSResponse> {
+    var theURL = new URL(partialURL, this._baseURL);
+    var myHeaders = new Headers();
+    myHeaders.append("Authorization", this.authorization);
+    var requestOptions = {
+      method: "DELETE",
+      headers: myHeaders,
+    };
+    const fetchPromise = fetch(theURL, requestOptions)
+      .then(async function (response) {
+        // Your code for handling the data you get from the API
+        if (response.status == 204) {
+          return new OFSResponse(theURL, response.status, undefined, undefined);
+        } else {
+          return new OFSResponse(
+            theURL,
+            response.status,
+            response.statusText,
+            await response.json()
+          );
+        }
+      })
+      .catch((error) => {
+        console.log("error", error);
+        return new OFSResponse(theURL, -1);
+      });
+    return fetchPromise;
+  }
+
+  // Core: Subscription Management
+  async getSubscriptions(
+    all: boolean = false
+  ): Promise<OFSSubscriptionResponse> {
+    const partialURL = "/rest/ofscCore/v1/events/subscriptions";
+    return this._get(partialURL, { allSubscriptions: all });
+  }
+
+  async createSubscription(data: any): Promise<OFSResponse> {
+    const partialURL = "/rest/ofscCore/v1/events/subscriptions/";
+    return this._post(partialURL, data);
+  }
+
+  async deleteSubscription(sid: string): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/events/subscriptions/${sid}`;
+    return this._delete(partialURL);
+  }
+
+  async getSubscriptionDetails(sid: string): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/events/subscriptions/${sid}`;
+    return this._get(partialURL);
+  }
+
+  // Core: Event Management
+  async getEvents(
+    sid: string,
+    page: string = "lastRequested",
+    since = null,
+    limit: number = 1000
+  ): Promise<OFSResponse> {
+    var params: {
+      subscriptionId: string;
+      page?: string;
+      limit: number;
+      since?: string | null;
+    } = {
+      subscriptionId: sid,
+      page: page,
+      limit: limit,
+      since: since,
+    };
+    if (since == null) {
+      delete params.since;
+    } else {
+      delete params.page;
+    }
+
+    const partialURL = "/rest/ofscCore/v1/events";
+    return this._get(partialURL, params);
+  }
+
+  // Core: Activity Management
+  async bulkUpdateActivity(data: OFSBulkUpdateRequest): Promise<OFSResponse> {
+    const partialURL = "/rest/ofscCore/v1/activities/custom-actions/bulkUpdate";
+    return this._post(partialURL, data);
+  }
+  async createActivity(data: any): Promise<OFSResponse> {
+    const partialURL = "/rest/ofscCore/v1/activities";
+    return this._post(partialURL, data);
+  }
+
+  async deleteActivity(aid: number): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}`;
+    return this._delete(partialURL);
+  }
+
+  async getActivityDetails(aid: number): Promise<OFSActivityResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}`;
+    return this._get(partialURL);
+  }
+  /**
+   * Retrieve activities linked to an existing activity
+   * @param aid Activity id to retrieve linked activities for
+   */
+  async getLinkedActivities(aid: number): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}/linkedActivities`;
+    return this._get(partialURL);
+  }
+
+  /**
+   * Retrieve the link type between two activities
+   * @param aid Activity id
+   * @param linkedActivityId Linked activity id
+   * @param linkType Type of link to retrieve
+   */
+  async getActivityLinkType(
+    aid: number,
+    linkedActivityId: number,
+    linkType: string
+  ): Promise<OFSActivityLinkTypeResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}/linkedActivities/${linkedActivityId}/linkTypes/${linkType}`;
+    return this._get(partialURL);
+  }
+  async updateActivity(aid: number, data: any): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}`;
+    return this._patch(partialURL, data);
+  }
+  async moveActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "move");
+  }
+  async delayActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "delay");
+  }
+  async reopenActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "reopen");
+  }
+  async startActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "start");
+  }
+  async suspendActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "suspend");
+  }
+  async completeActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "complete");
+  }
+  async stopTravel(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "stopTravel");
+  }
+  async cancelActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "cancel");
+  }
+  async startPrework(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "startPrework");
+  }
+  async enrouteActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "enroute");
+  }
+  async notDoneActivity(aid: number, data: any): Promise<OFSResponse> {
+    return this._executeActivityAction(aid, data, "notDone");
+  }
+  private async _executeActivityAction(
+    aid: number,
+    data: any,
+    action: any
+  ): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}/custom-actions/${action}`;
+    return this._post(partialURL, data);
+  }
+  async getActivityFilePropertyContent(
+    aid: number,
+    propertyLabel: string,
+    nediaType: string = "*/*"
+  ): Promise<OFSResponse> {
+    var myHeaders = new Headers();
+    myHeaders.append("Accept", nediaType);
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
+    return this._get(partialURL, undefined, myHeaders);
+  }
+
+  async getActivityFilePropertyMetadata(
+    aid: number,
+    propertyLabel: string
+  ): Promise<OFSResponse> {
+    var myHeaders = new Headers();
+    myHeaders.append("Accept", "*/*");
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
+    return this._get(partialURL, undefined, myHeaders);
+  }
+
+  async getActivityFileProperty(
+    aid: number,
+    propertyLabel: string
+  ): Promise<OFSResponse> {
+    var myHeaders = new Headers();
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
+    var metadata = await this.getActivityFilePropertyMetadata(
+      aid,
+      propertyLabel
+    );
+    if (metadata.status < 400) {
+      var contentType = metadata.contentType;
+      if (contentType) {
+        myHeaders.append("Accept", contentType);
+      }
+      var content = this._get(partialURL, undefined, myHeaders);
+      return new OFSResponse(
+        metadata.url,
+        metadata.status,
+        metadata.description,
+        {
+          ...metadata.data,
+          content: (await content).data,
+        },
+        metadata.contentType
+      );
+    } else {
+      return metadata;
+    }
+  }
+
+  async setActivityFileProperty(
+    aid: number,
+    propertyLabel: string,
+    blob: Blob,
+    fileName: string,
+    contentType: string = "*/*"
+  ): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${aid}/${propertyLabel}`;
+    return this._put(partialURL, blob, contentType, fileName);
+  }
+
+  async getSubmittedForms(
+    activityId: number,
+    params: OFSGetSubmittedFormsParams = {}
+  ): Promise<OFSSubmittedFormsResponse> {
+    const partialURL = `/rest/ofscCore/v1/activities/${activityId}/submittedForms`;
+    const queryParams: any = {
+      scope: params.scope !== undefined ? params.scope : "activity",
+    };
+
+    if (params.offset !== undefined) {
+      queryParams.offset = params.offset;
+    }
+    if (params.limit !== undefined) {
+      queryParams.limit = params.limit;
+    }
+
+    return this._get(partialURL, queryParams);
+  }
+
+  // Core: User Management
+  async getUsers(
+    offset: number = 0,
+    limit: number = 100
+  ): Promise<OFSResponse> {
+    const partialURL = "/rest/ofscCore/v1/users";
+    return this._get(partialURL, { offset: offset, limit: limit });
+  }
+
+  /**
+   * Retrieves all users from the OFS API.
+   * @returns An object containing all users.
+   */
+  async getAllUsers() {
+    const partialURL = "/rest/ofscCore/v1/users";
+    // Start with offset 0 and keep getting results until we get less than 100
+    var offset = 0;
+    var limit = 100;
+    var result: any = undefined;
+    var allResults: any = { totalResults: 0, items: [] };
+    do {
+      result = await this._get(partialURL, {
+        offset: offset,
+        limit: limit,
+      });
+      if (result.status < 400) {
+        if (allResults.totalResults == 0) {
+          allResults = result.data;
+        } else {
+          allResults.items = allResults.items.concat(result.data.items);
+        }
+        offset += limit;
+      } else {
+        return result;
+      }
+    } while (result.data.items.length == limit);
+    return allResults;
+  }
+
+  async getUserDetails(uname: string): Promise<OFSResponse> {
+    const partialURL = `/rest/ofscCore/v1/users/${uname}`;
+    return this._get(partialURL);
+  }
+
+  // Core: Resource Management
+  async getResources(
+    params: OFSGetResourcesParams = {}
+  ): Promise<OFSResourceResponse> {
+    const partialURL = "/rest/ofscCore/v1/resources";
+    const queryParams: any = {};
+
+    if (params.canBeTeamHolder !== undefined) {
+      queryParams.canBeTeamHolder = params.canBeTeamHolder;
+    }
+    if (params.canParticipateInTeam !== undefined) {
+      queryParams.canParticipateInTeam = params.canParticipateInTeam;
+    }
+    if (params.expand && params.expand.length > 0) {
+      queryParams.expand = params.expand.join(",");
+    }
+    if (params.fields && params.fields.length > 0) {
+      queryParams.fields = params.fields.join(",");
+    }
+    if (params.limit !== undefined) {
+      queryParams.limit = params.limit;
+    }
+    if (params.offset !== undefined) {
+      queryParams.offset = params.offset;
+    }
+
+    return this._get(partialURL, queryParams);
+  }
+
+  /**
+   * Retrieves all resources from the OFS API.
+   * @param params Optional parameters for filtering resources
+   * @returns An object containing all resources.
+   */
+  async getAllResources(
+    params: Omit<OFSGetResourcesParams, "limit" | "offset"> = {}
+  ) {
+    const partialURL = "/rest/ofscCore/v1/resources";
+    var offset = 0;
+    var limit = 100;
+    var result: any = undefined;
+    var allResults: any = { totalResults: 0, items: [] };
+
+    const queryParams: any = {};
+    if (params.canBeTeamHolder !== undefined) {
+      queryParams.canBeTeamHolder = params.canBeTeamHolder;
+    }
+    if (params.canParticipateInTeam !== undefined) {
+      queryParams.canParticipateInTeam = params.canParticipateInTeam;
+    }
+    if (params.expand && params.expand.length > 0) {
+      queryParams.expand = params.expand.join(",");
+    }
+    if (params.fields && params.fields.length > 0) {
+      queryParams.fields = params.fields.join(",");
+    }
+
+    do {
+      result = await this._get(partialURL, {
+        ...queryParams,
+        offset: offset,
+        limit: limit,
+      });
+      if (result.status < 400) {
+        if (allResults.totalResults == 0) {
+          allResults = result.data;
+        } else {
+          allResults.items = allResults.items.concat(result.data.items);
+        }
+        offset += limit;
+      } else {
+        return result;
+      }
+    } while (result.data.items.length == limit);
+    return allResults;
+  }
+
+  /**
+   * Retrieves a single resource by ID from the OFS API.
+   * @param resourceId The ID of the resource to retrieve
+   * @param params Optional parameters for expanding or filtering fields
+   * @returns The resource details
+   */
+  async getResource(
+    resourceId: string,
+    params: OFSGetResourceParams = {}
+  ): Promise<OFSSingleResourceResponse> {
+    const partialURL = `/rest/ofscCore/v1/resources/${resourceId}`;
+    const queryParams: any = {};
+
+    if (params.expand && params.expand.length > 0) {
+      queryParams.expand = params.expand.join(",");
+    }
+    if (params.fields && params.fields.length > 0) {
+      queryParams.fields = params.fields.join(",");
+    }
+
+    return this._get(
+      partialURL,
+      Object.keys(queryParams).length > 0 ? queryParams : undefined
+    );
+  }
+
+  /**
+   * Retrieves assistants for a given resource.
+   * @param resourceId The ID of the resource
+   * @param params Optional parameters for expanding/filtering fields and pagination
+   * @returns A paginated list of assistants for the resource
+   */
+  async getResourceAssistants(
+    resourceId: string,
+    params: OFSGetResourceAssistantsParams = {}
+  ): Promise<OFSResourceAssistantsResponse> {
+    const partialURL = `/rest/ofscCore/v1/resources/${resourceId}/assistants`;
+    const queryParams: any = {};
+    queryParams.dateFrom =
+      params.dateFrom || new Date().toISOString().split("T")[0];
+
+    if (params.expand && params.expand.length > 0) {
+      queryParams.expand = params.expand.join(",");
+    }
+    if (params.fields && params.fields.length > 0) {
+      queryParams.fields = params.fields.join(",");
+    }
+    if (params.limit !== undefined) {
+      queryParams.limit = params.limit;
+    }
+    if (params.offset !== undefined) {
+      queryParams.offset = params.offset;
+    }
+
+    return this._get(
+      partialURL,
+      Object.keys(queryParams).length > 0 ? queryParams : undefined
+    );
+  }
+
+  /**
+   * Retrieves all assistants for a given resource using pagination.
+   * @param resourceId The ID of the resource
+   * @param params Optional parameters for expanding/filtering fields (excludes pagination)
+   * @returns An object containing all assistants for the resource
+   */
+  async getAllResourceAssistants(
+    resourceId: string,
+    params: Omit<OFSGetResourceAssistantsParams, "limit" | "offset"> = {}
+  ) {
+    const partialURL = `/rest/ofscCore/v1/resources/${resourceId}/assistants`;
+    var offset = 0;
+    var limit = 100;
+    var result: any = undefined;
+    var allResults: any = { totalResults: 0, items: [] };
+
+    const queryParams: any = {};
+    queryParams.dateFrom =
+      params.dateFrom || new Date().toISOString().split("T")[0];
+
+    if (params.expand && params.expand.length > 0) {
+      queryParams.expand = params.expand.join(",");
+    }
+    if (params.fields && params.fields.length > 0) {
+      queryParams.fields = params.fields.join(",");
+    }
+
+    do {
+      result = await this._get(partialURL, {
+        ...queryParams,
+        offset: offset,
+        limit: limit,
+      });
+
+      if (result.status < 400) {
+        const pageItems = Array.isArray(result.data)
+          ? result.data
+          : result.data?.items || [];
+
+        if (allResults.totalResults == 0) {
+          if (Array.isArray(result.data)) {
+            allResults = { totalResults: 0, items: [] };
+          } else {
+            allResults = result.data;
+          }
         }
 
-        return this._postMultiPart(partialURL, formData);
-    }
-
-    //Meta: Property Management
-
-    async getProperties(
-        params: OFSGetPropertiesParams = { offset: 0, limit: 100 }
-    ): Promise<OFSPropertyListResponse> {
-        const partialURL = "/rest/ofscMetadata/v1/properties";
-        return this._get(partialURL, params);
-    }
-
-    //Meta: Link Templates
-    async getLinkTemplates(): Promise<OFSLinkTemplatesResponse> {
-        const partialURL = "/rest/ofscMetadata/v1/linkTemplates";
-        return this._get(partialURL) as Promise<OFSLinkTemplatesResponse>;
-    }
-
-    async getPropertyDetails(pid: string): Promise<OFSPropertyDetailsResponse> {
-        const partialURL = `/rest/ofscMetadata/v1/properties/${pid}`;
-        return this._get(partialURL);
-    }
-
-    async createReplaceProperty(
-        data: OFSPropertyDetails
-    ): Promise<OFSPropertyDetailsResponse> {
-        const partialURL = `/rest/ofscMetadata/v1/properties/${data.label}`;
-        return this._put(partialURL, data);
-    }
-
-    async updateProperty(
-        data: OFSPropertyDetails
-    ): Promise<OFSPropertyDetailsResponse> {
-        const partialURL = `/rest/ofscMetadata/v1/properties/${data.label}`;
-        return this._patch(partialURL, data);
-    }
-
-    //Meta: Timeslots
-    async getTimeslots(): Promise<OFSTimeslotsResponse> {
-        const partialURL = `/rest/ofscMetadata/v1/timeSlots`;
-        return this._get(partialURL);
-    }
-
-    // Capacity API: Booking Grid
-    /**
-     * Retrieves the time slots in which an activity can be performed.
-     * @param params Parameters for the booking grid request
-     * @returns The booking grid response with available time slots
-     */
-    async showBookingGrid(
-        params: OFSShowBookingGridParams
-    ): Promise<OFSShowBookingGridResponse> {
-        const partialURL = "/rest/ofscCapacity/v1/showBookingGrid";
-        return this._post(partialURL, params);
-    }
-
-    // Capacity API: Activity Booking Options
-    /**
-     * Retrieves available booking options for an activity type on specific dates.
-     * @param params Parameters for the activity booking options request
-     * @returns The activity booking options response with available time slots by date/area
-     */
-    async getActivityBookingOptions(
-        params: OFSGetActivityBookingOptionsParams
-    ): Promise<OFSGetActivityBookingOptionsResponse> {
-        const partialURL = "/rest/ofscCapacity/v1/activityBookingOptions";
-        const queryParams: any = {};
-
-        // Known array parameters that need CSV conversion
-        const arrayParams = ['dates', 'areas', 'categories'];
-
-        // Process all parameters
-        for (const [key, value] of Object.entries(params)) {
-            if (value === undefined) continue;
-
-            if (arrayParams.includes(key) && Array.isArray(value)) {
-                // Convert arrays to CSV format
-                if (value.length > 0) {
-                    queryParams[key] = value.join(',');
-                }
-            } else {
-                // Pass through all other parameters as-is
-                queryParams[key] = value;
-            }
+        if (allResults.items === undefined) {
+          allResults.items = [];
         }
 
-        return this._get(partialURL, queryParams);
+        if (allResults.totalResults === 0 && allResults.items.length === 0) {
+          allResults.items = pageItems;
+        } else {
+          allResults.items = allResults.items.concat(pageItems);
+        }
+
+        allResults.totalResults = allResults.items.length;
+
+        offset += limit;
+      } else {
+        return result;
+      }
+    } while (
+      (Array.isArray(result.data)
+        ? result.data.length
+        : result.data?.items?.length || 0) == limit
+    );
+
+    return allResults;
+  }
+
+  async getResourceRoutes(
+    resourceId: string,
+    date: string,
+    activityFields?: string[]
+  ): Promise<OFSResourceRoutesResponse> {
+    const partialURL = `/rest/ofscCore/v1/resources/${resourceId}/routes/${date}`;
+    const queryParams: any = {};
+
+    if (activityFields && activityFields.length > 0) {
+      queryParams.activityFields = activityFields.join(",");
     }
+
+    return this._get(partialURL, queryParams);
+  }
+
+  async getLastKnownPositions(
+    params: OFSGetLastKnownPositionsParams = {}
+  ): Promise<OFSLastKnownPositionsResponse> {
+    const partialURL =
+      "/rest/ofscCore/v1/resources/custom-actions/lastKnownPositions";
+    const queryParams: any = {};
+
+    if (params.offset !== undefined) {
+      queryParams.offset = params.offset;
+    }
+    if (params.resources && params.resources.length > 0) {
+      queryParams.resources = params.resources.join(",");
+    }
+
+    return this._get(partialURL, queryParams);
+  }
+
+  /**
+   * Retrieves all last known positions from the OFS API using pagination.
+   * @param params Optional parameters for filtering resources (excludes offset)
+   * @returns An object containing all last known positions.
+   */
+  async getAllLastKnownPositions(
+    params: Omit<OFSGetLastKnownPositionsParams, "offset"> = {}
+  ) {
+    const partialURL =
+      "/rest/ofscCore/v1/resources/custom-actions/lastKnownPositions";
+    var offset = 0;
+    var result: any = undefined;
+    var allResults: any = { totalResults: 0, items: [] };
+
+    const queryParams: any = {};
+    if (params.resources && params.resources.length > 0) {
+      queryParams.resources = params.resources.join(",");
+    }
+
+    do {
+      result = await this._get(partialURL, {
+        ...queryParams,
+        offset: offset,
+      });
+      if (result.status < 400) {
+        if (allResults.totalResults == 0) {
+          allResults = result.data;
+        } else {
+          allResults.items = allResults.items.concat(result.data.items);
+        }
+        // Update the total count to reflect actual accumulated items
+        allResults.totalResults = allResults.items.length;
+
+        // Increment offset by the number of items returned
+        offset += result.data.items.length;
+      } else {
+        return result;
+      }
+    } while (result.data.hasMore === true);
+
+    return allResults;
+  }
+
+  // Core: Activities Management
+  async getActivities(
+    params: OFSGetActivitiesParams,
+    offset: number = 0,
+    limit: number = 100
+  ): Promise<OFSResponse> {
+    const partialURL = "/rest/ofscCore/v1/activities";
+    return this._get(partialURL, {
+      ...params,
+      offset: offset,
+      limit: limit,
+    });
+  }
+
+  // Core: Activities Management
+  async searchForActivities(
+    params: OFSSearchForActivitiesParams,
+    offset: number = 0,
+    limit: number = 100
+  ): Promise<OFSResponse> {
+    const partialURL = "/rest/ofscCore/v1/activities/custom-actions/search";
+    return this._get(partialURL, {
+      ...params,
+      offset: offset,
+      limit: limit,
+    });
+  }
+  /**
+   * Retrieves all activities from the OFS API.
+   * @returns An object containing all activities.
+   */
+  async getAllActivities(params: OFSGetActivitiesParams, limit: number = 1000) {
+    const partialURL = "/rest/ofscCore/v1/activities";
+    // Start with offset 0 and keep getting results until we get less than 100
+    var offset = 0;
+
+    var result: any = undefined;
+    var allResults: any = {
+      status: 200,
+      detail: "",
+      title: "",
+      totalResults: 0,
+      items: [],
+    };
+    do {
+      result = await this._get(partialURL, {
+        ...params,
+        offset: offset,
+        limit: limit,
+      });
+      if (result.status == 200) {
+        if (allResults.totalResults == 0) {
+          allResults = result.data;
+          allResults.status = 200;
+        } else {
+          allResults.items = allResults.items.concat(result.data.items);
+        }
+        allResults.totalResults = allResults.items.length;
+        offset += limit;
+      } else {
+        return result;
+      }
+    } while (result.data.hasMore == true);
+    return allResults;
+  }
+  // Metadata: Plugin Management
+  async importPlugins(file?: PathLike, data?: string): Promise<OFSResponse> {
+    const partialURL = "/rest/ofscMetadata/v1/plugins/custom-actions/import";
+    var formData = new FormData();
+    if (file) {
+      var blob = new Blob([readFileSync(file)], { type: "text/xml" });
+
+      formData.append("pluginFile", blob, file.toString());
+    } else if (data) {
+      var blob = new Blob([data], { type: "text/xml" });
+      formData.append("pluginFile", blob, "plugin.xml");
+    } else {
+      throw "Must provide file or data";
+    }
+
+    return this._postMultiPart(partialURL, formData);
+  }
+
+  //Meta: Property Management
+
+  async getProperties(
+    params: OFSGetPropertiesParams = { offset: 0, limit: 100 }
+  ): Promise<OFSPropertyListResponse> {
+    const partialURL = "/rest/ofscMetadata/v1/properties";
+    return this._get(partialURL, params);
+  }
+
+  //Meta: Link Templates
+  async getLinkTemplates(): Promise<OFSLinkTemplatesResponse> {
+    const partialURL = "/rest/ofscMetadata/v1/linkTemplates";
+    return this._get(partialURL) as Promise<OFSLinkTemplatesResponse>;
+  }
+
+  async getForms(
+    params: OFSGetFormsParams = { offset: 0, limit: 100 }
+  ): Promise<OFSFormsResponse> {
+    const partialURL = "/rest/ofscMetadata/v1/forms";
+    return this._get(partialURL, params) as Promise<OFSFormsResponse>;
+  }
+
+  async getAllForms(
+    params: Omit<OFSGetFormsParams, "limit" | "offset"> = {},
+    limit: number = 100
+  ) {
+    const partialURL = "/rest/ofscMetadata/v1/forms";
+    var offset = 0;
+
+    var result: any = undefined;
+    var allResults: any = {
+      hasMore: false,
+      totalResults: 0,
+      offset: 0,
+      limit: limit,
+      items: [],
+    };
+    do {
+      result = await this._get(partialURL, {
+        ...params,
+        offset: offset,
+        limit: limit,
+      });
+      if (result.status == 200) {
+        if (allResults.totalResults == 0) {
+          allResults = result.data;
+        } else {
+          allResults.items = allResults.items.concat(result.data.items);
+        }
+        allResults.totalResults = allResults.items.length;
+        allResults.hasMore = result.data.hasMore;
+        offset += limit;
+      } else {
+        return result;
+      }
+    } while (result.data.hasMore == true);
+    return allResults;
+  }
+
+  async getPropertyDetails(pid: string): Promise<OFSPropertyDetailsResponse> {
+    const partialURL = `/rest/ofscMetadata/v1/properties/${pid}`;
+    return this._get(partialURL);
+  }
+
+  async getFormDetails(
+    label: string,
+    params: OFSGetFormDetailsParams = {}
+  ): Promise<OFSFormDetailsResponse> {
+    const partialURL = `/rest/ofscMetadata/v1/forms/${label}`;
+    const queryParams = Object.keys(params).length > 0 ? params : undefined;
+    return this._get(
+      partialURL,
+      queryParams
+    ) as Promise<OFSFormDetailsResponse>;
+  }
+
+  async createReplaceProperty(
+    data: OFSPropertyDetails
+  ): Promise<OFSPropertyDetailsResponse> {
+    const partialURL = `/rest/ofscMetadata/v1/properties/${data.label}`;
+    return this._put(partialURL, data);
+  }
+
+  async updateProperty(
+    data: OFSPropertyDetails
+  ): Promise<OFSPropertyDetailsResponse> {
+    const partialURL = `/rest/ofscMetadata/v1/properties/${data.label}`;
+    return this._patch(partialURL, data);
+  }
+
+  //Meta: Timeslots
+  async getTimeslots(): Promise<OFSTimeslotsResponse> {
+    const partialURL = `/rest/ofscMetadata/v1/timeSlots`;
+    return this._get(partialURL);
+  }
+
+  // Capacity API: Booking Grid
+  /**
+   * Retrieves the time slots in which an activity can be performed.
+   * @param params Parameters for the booking grid request
+   * @returns The booking grid response with available time slots
+   */
+  async showBookingGrid(
+    params: OFSShowBookingGridParams
+  ): Promise<OFSShowBookingGridResponse> {
+    const partialURL = "/rest/ofscCapacity/v1/showBookingGrid";
+    return this._post(partialURL, params);
+  }
+
+  // Capacity API: Activity Booking Options
+  /**
+   * Retrieves available booking options for an activity type on specific dates.
+   * @param params Parameters for the activity booking options request
+   * @returns The activity booking options response with available time slots by date/area
+   */
+  async getActivityBookingOptions(
+    params: OFSGetActivityBookingOptionsParams
+  ): Promise<OFSGetActivityBookingOptionsResponse> {
+    const partialURL = "/rest/ofscCapacity/v1/activityBookingOptions";
+    const queryParams: any = {};
+
+    // Known array parameters that need CSV conversion
+    const arrayParams = ["dates", "areas", "categories"];
+
+    // Process all parameters
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined) continue;
+
+      if (arrayParams.includes(key) && Array.isArray(value)) {
+        // Convert arrays to CSV format
+        if (value.length > 0) {
+          queryParams[key] = value.join(",");
+        }
+      } else {
+        // Pass through all other parameters as-is
+        queryParams[key] = value;
+      }
+    }
+
+    return this._get(partialURL, queryParams);
+  }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,17 +1,17 @@
 export interface OFSLinkTemplate {
-    linkTemplateId: string;
-    name: string;
-    description?: string;
-    linkType: string;
-    sourceType: string;
-    targetType: string;
-    links?: any;
+  linkTemplateId: string;
+  name: string;
+  description?: string;
+  linkType: string;
+  sourceType: string;
+  targetType: string;
+  links?: any;
 }
 
 export interface OFSLinkTemplatesData {
-    totalResults: number;
-    items: OFSLinkTemplate[];
-    links?: any;
+  totalResults: number;
+  items: OFSLinkTemplate[];
+  links?: any;
 }
 
 // ...existing code...
@@ -33,614 +33,665 @@ export interface OFSLinkTemplatesData {
 import { off } from "process";
 
 export type OFSCredentials = {
-    instance?: string;
-    clientId?: string;
-    clientSecret?: string;
-    token?: string;
-    baseURL?: string;
+  instance?: string;
+  clientId?: string;
+  clientSecret?: string;
+  token?: string;
+  baseURL?: string;
 };
 
 export interface OFSResponseInterface {
-    status: number;
-    description: string | undefined;
-    data: any;
-    url: URL;
-    contentType?: string;
+  status: number;
+  description: string | undefined;
+  data: any;
+  url: URL;
+  contentType?: string;
 }
 
 export class OFSResponse implements OFSResponseInterface {
-    status: number = -1;
-    description: string | undefined;
-    data: any;
-    url: URL;
-    contentType?: string;
+  status: number = -1;
+  description: string | undefined;
+  data: any;
+  url: URL;
+  contentType?: string;
 
-    constructor(
-        url: URL,
-        status: number,
-        description?: string,
-        data?: any,
-        contentType?: string
-    ) {
-        this.status = status;
-        this.description = description;
-        this.data = data;
-        this.url = url;
-        this.contentType = contentType;
-    }
+  constructor(
+    url: URL,
+    status: number,
+    description?: string,
+    data?: any,
+    contentType?: string
+  ) {
+    this.status = status;
+    this.description = description;
+    this.data = data;
+    this.url = url;
+    this.contentType = contentType;
+  }
 }
 
 export class OFSLinkTemplatesResponse extends OFSResponse {
-    data: {
-        totalResults: number;
-        items: OFSLinkTemplate[];
-        links?: any;
-    } = {
-        totalResults: 0,
-        items: [],
-        links: undefined,
-    };
+  data: {
+    totalResults: number;
+    items: OFSLinkTemplate[];
+    links?: any;
+  } = {
+    totalResults: 0,
+    items: [],
+    links: undefined,
+  };
 }
 
 export interface ListResponse {
-    totalResults: number;
-    items: Array<any>;
-    links: any;
+  totalResults: number;
+  items: Array<any>;
+  links: any;
 }
 export interface Subscription {
-    subscriptionId: string;
-    applicationId: string;
-    createdTime: string;
-    expirationTime: string;
-    subscriptionTitle: string;
-    subscriptionConfig: any;
-    links: any;
+  subscriptionId: string;
+  applicationId: string;
+  createdTime: string;
+  expirationTime: string;
+  subscriptionTitle: string;
+  subscriptionConfig: any;
+  links: any;
 }
 
 export interface ActivityResponse {
-    customerName: any;
-    activityId: number;
+  customerName: any;
+  activityId: number;
 }
 
 export interface SubscriptionListResponse {
-    totalResults: number;
-    items: Array<Subscription>;
-    links: any;
+  totalResults: number;
+  items: Array<Subscription>;
+  links: any;
 }
 
 export interface ActivityListResponse {
-    totalResults: number;
-    items: Array<Subscription>;
-    links: any;
+  totalResults: number;
+  items: Array<Subscription>;
+  links: any;
 }
 
 export interface OFSTranslation {
-    language: string;
-    name: string;
-    languageISO: string;
+  language: string;
+  name: string;
+  languageISO: string;
 }
 export interface OFSPropertyDetails {
-    label: string;
-    name?: string;
-    type?: string;
-    entity?: string;
-    gui?: string;
-    allowDraw?: boolean;
-    cloneFlag?: boolean;
-    fileSizeLimit?: string;
-    getGeolocation?: boolean;
-    hint?: string;
-    lines?: number;
-    maxHeight?: number;
-    maxWidth?: number;
-    mimeTypes?: [];
-    template?: string;
-    transformation?: any;
-    watermark?: boolean;
-    translations?: OFSTranslation[];
-    links?: any;
+  label: string;
+  name?: string;
+  type?: string;
+  entity?: string;
+  gui?: string;
+  allowDraw?: boolean;
+  cloneFlag?: boolean;
+  fileSizeLimit?: string;
+  getGeolocation?: boolean;
+  hint?: string;
+  lines?: number;
+  maxHeight?: number;
+  maxWidth?: number;
+  mimeTypes?: [];
+  template?: string;
+  transformation?: any;
+  watermark?: boolean;
+  translations?: OFSTranslation[];
+  links?: any;
+}
+
+export interface OFSFormDetails {
+  label: string;
+  name: string;
+  translations?: OFSTranslation[];
+  content: Record<string, any> | string;
+  links?: any;
+}
+
+export interface OFSFormSummary {
+  label: string;
+  name: string;
+  translations?: OFSTranslation[];
+  links?: any;
 }
 
 export interface OFSGetPropertiesParams {
-    entity?: string;
-    language?: string;
-    limit?: number;
-    offset?: number;
-    type?: number;
+  entity?: string;
+  language?: string;
+  limit?: number;
+  offset?: number;
+  type?: number;
 }
+
+export interface OFSGetFormsParams {
+  language?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface OFSGetFormDetailsParams {
+  language?: string;
+}
+
+export class OFSFormsList {
+  hasMore: boolean = false;
+  items: OFSFormSummary[] = [];
+  limit: number = 0;
+  offset: number = 0;
+  totalResults: number = 0;
+}
+
 export class OFSPropertyList {
-    items: OFSPropertyDetails[] = [];
-    limit: number = 0;
-    offset: number = 0;
-    totalResults: number = 0;
+  items: OFSPropertyDetails[] = [];
+  limit: number = 0;
+  offset: number = 0;
+  totalResults: number = 0;
 }
 export class OFSTimeslot {
-    active: boolean = false;
-    isAllDay: boolean = false;
-    timeEnd: string = "";
-    timeStart: string = "";
-    label: string = "";
-    name: string = "";
+  active: boolean = false;
+  isAllDay: boolean = false;
+  timeEnd: string = "";
+  timeStart: string = "";
+  label: string = "";
+  name: string = "";
 }
 export class OFSTimeslotsList {
-    items: OFSTimeslot[] = [];
-    limit: number = 0;
-    offset: number = 0;
-    totalResults: number = 0;
+  items: OFSTimeslot[] = [];
+  limit: number = 0;
+  offset: number = 0;
+  totalResults: number = 0;
 }
 export class OFSSubscriptionResponse extends OFSResponse {
-    data: SubscriptionListResponse = {
-        totalResults: 0,
-        items: [],
-        links: undefined,
-    };
+  data: SubscriptionListResponse = {
+    totalResults: 0,
+    items: [],
+    links: undefined,
+  };
 }
 
 export class OFSActivityResponse extends OFSResponse {
-    data: ActivityResponse = {
-        customerName: undefined,
-        activityId: 0,
-    };
+  data: ActivityResponse = {
+    customerName: undefined,
+    activityId: 0,
+  };
 }
 
 export interface OFSLinkedActivitiesData {
-    totalResults: number;
-    items: ActivityResponse[];
-    links?: any;
+  totalResults: number;
+  items: ActivityResponse[];
+  links?: any;
 }
 
 export class OFSLinkedActivitiesResponse extends OFSResponse {
-    data: OFSLinkedActivitiesData = {
-        totalResults: 0,
-        items: [],
-        links: undefined,
-    };
+  data: OFSLinkedActivitiesData = {
+    totalResults: 0,
+    items: [],
+    links: undefined,
+  };
 }
 
 export interface OFSActivityLinkTypeData {
-    linkType: string;
-    links?: any;
+  linkType: string;
+  links?: any;
 }
 
 export class OFSActivityLinkTypeResponse extends OFSResponse {
-    data: OFSActivityLinkTypeData = {
-        linkType: '',
-        links: undefined
-    };
+  data: OFSActivityLinkTypeData = {
+    linkType: "",
+    links: undefined,
+  };
 }
 
 export class OFSPropertyDetailsResponse extends OFSResponse {
-    data: OFSPropertyDetails = {
-        label: "",
-        name: "",
-        type: "string",
-        entity: "activity",
-        gui: "",
-        translations: [],
-        links: undefined,
-    };
+  data: OFSPropertyDetails = {
+    label: "",
+    name: "",
+    type: "string",
+    entity: "activity",
+    gui: "",
+    translations: [],
+    links: undefined,
+  };
+}
+
+export class OFSFormDetailsResponse extends OFSResponse {
+  data: OFSFormDetails = {
+    label: "",
+    name: "",
+    content: {},
+    translations: [],
+    links: undefined,
+  };
+}
+
+export class OFSFormsResponse extends OFSResponse {
+  data: OFSFormsList = new OFSFormsList();
 }
 
 export class OFSPropertyListResponse extends OFSResponse {
-    data: OFSPropertyList = new OFSPropertyList();
+  data: OFSPropertyList = new OFSPropertyList();
 }
 
 export class OFSTimeslotsResponse extends OFSResponse {
-    data: OFSTimeslotsList = new OFSTimeslotsList();
+  data: OFSTimeslotsList = new OFSTimeslotsList();
 }
 
 export interface OFSGetActivitiesParams {
-    resources: string;
-    dateFrom?: string;
-    dateTo?: string;
-    fields?: string;
-    includeChildren?: string;
-    includeNonScheduled?: boolean;
-    q?: string;
+  resources: string;
+  dateFrom?: string;
+  dateTo?: string;
+  fields?: string;
+  includeChildren?: string;
+  includeNonScheduled?: boolean;
+  q?: string;
 }
 
 export interface OFSSearchForActivitiesParams {
-    dateFrom: string;
-    dateTo: string;
-    searchForValue: string;
-    searchInField: string;
-    fields?: string;
-    includeMultiday?: string;
-    includeNonScheduled?: boolean;
+  dateFrom: string;
+  dateTo: string;
+  searchForValue: string;
+  searchInField: string;
+  fields?: string;
+  includeMultiday?: string;
+  includeNonScheduled?: boolean;
 }
 
 export interface OFSBulkUpdateRequestInterface {
-    activities: any[];
-    updateParameters: OFSBulkUpdateRequestParamsInterface;
+  activities: any[];
+  updateParameters: OFSBulkUpdateRequestParamsInterface;
 }
 
 export class OFSBulkUpdateRequest implements OFSBulkUpdateRequestInterface {
-    activities: any[] = [];
-    updateParameters: OFSBulkUpdateRequestParams = {
-        ifInFinalStatusThen: "doNothing",
-        identifyActivityBy: "apptNumber",
-        ifExistsThenDoNotUpdateFields: [],
-    };
+  activities: any[] = [];
+  updateParameters: OFSBulkUpdateRequestParams = {
+    ifInFinalStatusThen: "doNothing",
+    identifyActivityBy: "apptNumber",
+    ifExistsThenDoNotUpdateFields: [],
+  };
 
-    constructor(
-        activities: any[],
-        updateParameters?: OFSBulkUpdateRequestParams
-    ) {
-        this.activities = activities;
-        this.updateParameters = updateParameters || {
-            ifInFinalStatusThen: "doNothing",
-            identifyActivityBy: "apptNumber",
-            ifExistsThenDoNotUpdateFields: [],
-        };
-    }
+  constructor(
+    activities: any[],
+    updateParameters?: OFSBulkUpdateRequestParams
+  ) {
+    this.activities = activities;
+    this.updateParameters = updateParameters || {
+      ifInFinalStatusThen: "doNothing",
+      identifyActivityBy: "apptNumber",
+      ifExistsThenDoNotUpdateFields: [],
+    };
+  }
 }
 export interface OFSBulkUpdateRequestParamsInterface {
-    fallbackResourceId?: string;
-    identifyActivityBy?: string;
-    ifExistsThenDoNotUpdateFields?: any[];
-    ifInFinalStatusThen: string;
-    inventoryPropertiesUpdateMode?: string;
+  fallbackResourceId?: string;
+  identifyActivityBy?: string;
+  ifExistsThenDoNotUpdateFields?: any[];
+  ifInFinalStatusThen: string;
+  inventoryPropertiesUpdateMode?: string;
 }
 
 export class OFSBulkUpdateRequestParams
-    implements OFSBulkUpdateRequestParamsInterface
+  implements OFSBulkUpdateRequestParamsInterface
 {
-    fallbackResourceId?: string;
-    identifyActivityBy: string = "apptNumber"; // default value
-    ifExistsThenDoNotUpdateFields: any[] = [];
-    ifInFinalStatusThen: string = "doNothing"; // default value
-    inventoryPropertiesUpdateMode?: string;
+  fallbackResourceId?: string;
+  identifyActivityBy: string = "apptNumber"; // default value
+  ifExistsThenDoNotUpdateFields: any[] = [];
+  ifInFinalStatusThen: string = "doNothing"; // default value
+  inventoryPropertiesUpdateMode?: string;
 
-    constructor(
-        fallbackResourceId?: string,
-        identifyActivityBy?: string,
-        ifExistsThenDoNotUpdateFields?: any[],
-        ifInFinalStatusThen?: string,
-        inventoryPropertiesUpdateMode?: string
-    ) {
-        this.fallbackResourceId = fallbackResourceId;
-        if (identifyActivityBy) {
-            this.identifyActivityBy = identifyActivityBy;
-        }
-        if (ifExistsThenDoNotUpdateFields) {
-            this.ifExistsThenDoNotUpdateFields = ifExistsThenDoNotUpdateFields;
-        }
-        if (ifInFinalStatusThen) {
-            this.ifInFinalStatusThen = ifInFinalStatusThen;
-        }
-        this.inventoryPropertiesUpdateMode = inventoryPropertiesUpdateMode;
+  constructor(
+    fallbackResourceId?: string,
+    identifyActivityBy?: string,
+    ifExistsThenDoNotUpdateFields?: any[],
+    ifInFinalStatusThen?: string,
+    inventoryPropertiesUpdateMode?: string
+  ) {
+    this.fallbackResourceId = fallbackResourceId;
+    if (identifyActivityBy) {
+      this.identifyActivityBy = identifyActivityBy;
     }
+    if (ifExistsThenDoNotUpdateFields) {
+      this.ifExistsThenDoNotUpdateFields = ifExistsThenDoNotUpdateFields;
+    }
+    if (ifInFinalStatusThen) {
+      this.ifInFinalStatusThen = ifInFinalStatusThen;
+    }
+    this.inventoryPropertiesUpdateMode = inventoryPropertiesUpdateMode;
+  }
 }
 
 export interface OFSGetResourcesParams {
-    canBeTeamHolder?: boolean;
-    canParticipateInTeam?: boolean;
-    expand?: string[];
-    fields?: string[];
-    limit?: number;
-    offset?: number;
+  canBeTeamHolder?: boolean;
+  canParticipateInTeam?: boolean;
+  expand?: string[];
+  fields?: string[];
+  limit?: number;
+  offset?: number;
 }
 
 export interface OFSResource {
-    resourceId: string;
-    name: string;
-    status: string;
-    resourceType: string;
-    email?: string;
-    phone?: string;
-    language?: string;
-    timeZone?: string;
+  resourceId: string;
+  name: string;
+  status: string;
+  resourceType: string;
+  email?: string;
+  phone?: string;
+  language?: string;
+  timeZone?: string;
 }
 
 export interface OFSResourceListResponse {
-    totalResults: number;
-    limit: number;
-    offset: number;
-    items: OFSResource[];
-    links?: any;
+  totalResults: number;
+  limit: number;
+  offset: number;
+  items: OFSResource[];
+  links?: any;
 }
 
 export class OFSResourceResponse extends OFSResponse {
-    data: OFSResourceListResponse = {
-        totalResults: 0,
-        limit: 100,
-        offset: 0,
-        items: [],
-        links: undefined,
-    };
+  data: OFSResourceListResponse = {
+    totalResults: 0,
+    limit: 100,
+    offset: 0,
+    items: [],
+    links: undefined,
+  };
 }
 
 export interface OFSGetResourceParams {
-    expand?: string[];
-    fields?: string[];
+  expand?: string[];
+  fields?: string[];
 }
 
 export interface OFSGetResourceAssistantsParams {
-    dateFrom?: string;
-    expand?: string[];
-    fields?: string[];
-    limit?: number;
-    offset?: number;
+  dateFrom?: string;
+  expand?: string[];
+  fields?: string[];
+  limit?: number;
+  offset?: number;
 }
 
 export class OFSSingleResourceResponse extends OFSResponse {
-    data: OFSResource = {
-        resourceId: '',
-        name: '',
-        status: '',
-        resourceType: '',
-    };
+  data: OFSResource = {
+    resourceId: "",
+    name: "",
+    status: "",
+    resourceType: "",
+  };
 }
 
 export interface OFSResourceAssistantsData {
-    totalResults: number;
-    limit?: number;
-    offset?: number;
-    hasMore?: boolean;
-    items: OFSResource[];
-    links?: any;
+  totalResults: number;
+  limit?: number;
+  offset?: number;
+  hasMore?: boolean;
+  items: OFSResource[];
+  links?: any;
 }
 
 export class OFSResourceAssistantsResponse extends OFSResponse {
-    data: OFSResourceAssistantsData = {
-        totalResults: 0,
-        limit: 100,
-        offset: 0,
-        items: [],
-        links: undefined,
-    };
+  data: OFSResourceAssistantsData = {
+    totalResults: 0,
+    limit: 100,
+    offset: 0,
+    items: [],
+    links: undefined,
+  };
 }
 
 export interface OFSGetResourceRoutesParams {
-    resourceId: string;
-    date: string;
-    activityFields?: string[];
+  resourceId: string;
+  date: string;
+  activityFields?: string[];
 }
 
 export interface OFSRouteActivity {
-    activityId: number;
-    latitude?: number;
-    longitude?: number;
-    status?: string;
-    [key: string]: any;
+  activityId: number;
+  latitude?: number;
+  longitude?: number;
+  status?: string;
+  [key: string]: any;
 }
 
 export interface OFSResourceRoutesData {
-    routeStartTime?: string;
-    totalResults: number;
-    limit: number;
-    offset: number;
-    items: OFSRouteActivity[];
-    links?: any[];
-    [key: string]: any;
+  routeStartTime?: string;
+  totalResults: number;
+  limit: number;
+  offset: number;
+  items: OFSRouteActivity[];
+  links?: any[];
+  [key: string]: any;
 }
 
 export class OFSResourceRoutesResponse extends OFSResponse {
-    data: OFSResourceRoutesData = {
-        totalResults: 0,
-        limit: 100,
-        offset: 0,
-        items: [],
-    };
+  data: OFSResourceRoutesData = {
+    totalResults: 0,
+    limit: 100,
+    offset: 0,
+    items: [],
+  };
 }
 
 export interface OFSGetLastKnownPositionsParams {
-    offset?: number;
-    resources?: string[];
+  offset?: number;
+  resources?: string[];
 }
 
 export interface OFSLastKnownPosition {
-    resourceId: string;
-    time?: string;
-    lat?: number;
-    lng?: number;
-    errorMessage?: string;
+  resourceId: string;
+  time?: string;
+  lat?: number;
+  lng?: number;
+  errorMessage?: string;
 }
 
 export interface OFSLastKnownPositionsData {
-    totalResults: number;
-    items: OFSLastKnownPosition[];
-    hasMore?: boolean;
+  totalResults: number;
+  items: OFSLastKnownPosition[];
+  hasMore?: boolean;
 }
 
 export class OFSLastKnownPositionsResponse extends OFSResponse {
-    data: OFSLastKnownPositionsData = {
-        totalResults: 0,
-        items: [],
-    };
+  data: OFSLastKnownPositionsData = {
+    totalResults: 0,
+    items: [],
+  };
 }
 
 export interface OFSGetSubmittedFormsParams {
-    offset?: number;
-    limit?: number;
-    scope?: string;
+  offset?: number;
+  limit?: number;
+  scope?: string;
 }
 
 export interface OFSFormIdentifier {
-    formSubmitId: string;
-    formLabel: string;
+  formSubmitId: string;
+  formLabel: string;
 }
 
 export interface OFSSubmittedFormItem {
-    time: string;
-    user: string;
-    formIdentifier: OFSFormIdentifier;
-    formDetails: { [key: string]: any };
-    activityDetails?: { [key: string]: any };
-    resourceDetails?: { [key: string]: any };
+  time: string;
+  user: string;
+  formIdentifier: OFSFormIdentifier;
+  formDetails: { [key: string]: any };
+  activityDetails?: { [key: string]: any };
+  resourceDetails?: { [key: string]: any };
 }
 
 export interface OFSSubmittedFormsData {
-    hasMore: boolean;
-    totalResults: number;
-    offset: number;
-    limit: number;
-    items: OFSSubmittedFormItem[];
-    links?: any[];
+  hasMore: boolean;
+  totalResults: number;
+  offset: number;
+  limit: number;
+  items: OFSSubmittedFormItem[];
+  links?: any[];
 }
 
 export class OFSSubmittedFormsResponse extends OFSResponse {
-    data: OFSSubmittedFormsData = {
-        hasMore: false,
-        totalResults: 0,
-        offset: 0,
-        limit: 100,
-        items: [],
-    };
+  data: OFSSubmittedFormsData = {
+    hasMore: false,
+    totalResults: 0,
+    offset: 0,
+    limit: 100,
+    items: [],
+  };
 }
 
 // Capacity API: showBookingGrid
 export interface OFSShowBookingGridParams {
-    activity: Record<string, any>;
-    dateFrom: string;
-    dateTo?: string;
-    identifyActivityBy?: 'activityId' | 'apptNumber' | 'apptNumberPlusCustomerNumber';
-    includeResourcesDictionary?: boolean;
-    includeTimeSlotsDictionary?: boolean;
-    returnReasons?: boolean;
-    resourceFields?: string[];
-    lateStartMitigation?: number;
-    forecastDuringBooking?: Record<string, any>;
+  activity: Record<string, any>;
+  dateFrom: string;
+  dateTo?: string;
+  identifyActivityBy?:
+    | "activityId"
+    | "apptNumber"
+    | "apptNumberPlusCustomerNumber";
+  includeResourcesDictionary?: boolean;
+  includeTimeSlotsDictionary?: boolean;
+  returnReasons?: boolean;
+  resourceFields?: string[];
+  lateStartMitigation?: number;
+  forecastDuringBooking?: Record<string, any>;
 }
 
 export interface OFSBookingGridTimeSlot {
-    label: string;
-    originalQuota?: number;
-    remainingQuota?: number;
-    reason?: string;
-    recommendationInfo?: {
-        additionalTravel?: number;
-        travelKeyMatch?: boolean;
-    };
-    setPositionInRoute?: string;
+  label: string;
+  originalQuota?: number;
+  remainingQuota?: number;
+  reason?: string;
+  recommendationInfo?: {
+    additionalTravel?: number;
+    travelKeyMatch?: boolean;
+  };
+  setPositionInRoute?: string;
 }
 
 export interface OFSBookingGridDate {
-    date: string;
-    timeSlots: OFSBookingGridTimeSlot[];
+  date: string;
+  timeSlots: OFSBookingGridTimeSlot[];
 }
 
 export interface OFSBookingGridArea {
-    label: string;
-    name?: string;
-    bucket?: string;
-    timeZone?: string;
-    timeZoneDiff?: number;
-    areaTimeSlots?: string[];
-    averageBucketTravel?: number;
-    dates: OFSBookingGridDate[];
+  label: string;
+  name?: string;
+  bucket?: string;
+  timeZone?: string;
+  timeZoneDiff?: number;
+  areaTimeSlots?: string[];
+  averageBucketTravel?: number;
+  dates: OFSBookingGridDate[];
 }
 
 export interface OFSTimeSlotDictionary {
-    label: string;
-    name?: string;
-    timeStart?: string;
-    timeEnd?: string;
-    active?: boolean;
-    isAllDay?: boolean;
+  label: string;
+  name?: string;
+  timeStart?: string;
+  timeEnd?: string;
+  active?: boolean;
+  isAllDay?: boolean;
 }
 
 export interface OFSResourceDictionary {
-    resourceId: string;
-    [key: string]: any;
+  resourceId: string;
+  [key: string]: any;
 }
 
 export interface OFSShowBookingGridData {
-    actualAtTime?: string;
-    duration?: number;
-    travelTime?: number;
-    workZone?: string;
-    areas: OFSBookingGridArea[];
-    resourcesDictionary?: OFSResourceDictionary[];
-    timeSlotsDictionary?: OFSTimeSlotDictionary[];
+  actualAtTime?: string;
+  duration?: number;
+  travelTime?: number;
+  workZone?: string;
+  areas: OFSBookingGridArea[];
+  resourcesDictionary?: OFSResourceDictionary[];
+  timeSlotsDictionary?: OFSTimeSlotDictionary[];
 }
 
 export class OFSShowBookingGridResponse extends OFSResponse {
-    data: OFSShowBookingGridData = {
-        areas: [],
-    };
+  data: OFSShowBookingGridData = {
+    areas: [],
+  };
 }
 
 // Capacity API: getActivityBookingOptions
 export interface OFSGetActivityBookingOptionsParams {
-    /** The type of the activity. Based on the activity type, predefined company-specific rules are applied (required) */
-    activityType: string;
-    /** The dates for which the booking options are requested in YYYY-MM-DD format (required) */
-    dates: string[];
-    /** Capacity area labels; if omitted and determineAreaByWorkZone=false, processes all visible areas */
-    areas?: string[];
-    /** Capacity category labels for filtering */
-    categories?: string[];
-    /** Customer city location; used for geocoding */
-    city?: string;
-    /** Customer postal code; used for geocoding */
-    postalCode?: string;
-    /** Customer state/province; used for geocoding */
-    stateProvince?: string;
-    /** Customer street address; used for geocoding */
-    streetAddress?: string;
-    /** Activity location latitude coordinate in degrees (-90 to 90) */
-    latitude?: number;
-    /** Activity location longitude coordinate in degrees (-180 to 180) */
-    longitude?: number;
-    /** If true, estimates activity duration using statistics. Default: true */
-    estimateDuration?: boolean;
-    /** If true, estimates travel time using statistics when configured. Default: true */
-    estimateTravelTime?: boolean;
-    /** If true, determines categories from work skill conditions. Default: true */
-    determineCategory?: boolean;
-    /** If true, determines work zone automatically; requires all work zone key fields. Default: true */
-    determineAreaByWorkZone?: boolean;
-    /** Duration in minutes when estimation disabled or statistical record unavailable. Default: activity type default */
-    defaultDuration?: number;
-    /** For day-0 bookings: only returns intervals starting after currentTime + this value (minutes) */
-    minTimeBeforeArrival?: number;
-    /** If true, returns areas with at least one matching category. Default: false */
-    includePartiallyDefinedCategories?: boolean;
-    /** Allow additional custom parameters as key-value pairs */
-    [key: string]: string | string[] | number | boolean | undefined;
+  /** The type of the activity. Based on the activity type, predefined company-specific rules are applied (required) */
+  activityType: string;
+  /** The dates for which the booking options are requested in YYYY-MM-DD format (required) */
+  dates: string[];
+  /** Capacity area labels; if omitted and determineAreaByWorkZone=false, processes all visible areas */
+  areas?: string[];
+  /** Capacity category labels for filtering */
+  categories?: string[];
+  /** Customer city location; used for geocoding */
+  city?: string;
+  /** Customer postal code; used for geocoding */
+  postalCode?: string;
+  /** Customer state/province; used for geocoding */
+  stateProvince?: string;
+  /** Customer street address; used for geocoding */
+  streetAddress?: string;
+  /** Activity location latitude coordinate in degrees (-90 to 90) */
+  latitude?: number;
+  /** Activity location longitude coordinate in degrees (-180 to 180) */
+  longitude?: number;
+  /** If true, estimates activity duration using statistics. Default: true */
+  estimateDuration?: boolean;
+  /** If true, estimates travel time using statistics when configured. Default: true */
+  estimateTravelTime?: boolean;
+  /** If true, determines categories from work skill conditions. Default: true */
+  determineCategory?: boolean;
+  /** If true, determines work zone automatically; requires all work zone key fields. Default: true */
+  determineAreaByWorkZone?: boolean;
+  /** Duration in minutes when estimation disabled or statistical record unavailable. Default: activity type default */
+  defaultDuration?: number;
+  /** For day-0 bookings: only returns intervals starting after currentTime + this value (minutes) */
+  minTimeBeforeArrival?: number;
+  /** If true, returns areas with at least one matching category. Default: false */
+  includePartiallyDefinedCategories?: boolean;
+  /** Allow additional custom parameters as key-value pairs */
+  [key: string]: string | string[] | number | boolean | undefined;
 }
 
 export interface OFSBookingOptionsTimeSlot {
-    label: string;
-    originalQuota?: number;
-    remainingQuota?: number;
-    reason?: string;
-    recommendationInfo?: {
-        additionalTravel?: number;
-        travelKeyMatch?: boolean;
-    };
+  label: string;
+  originalQuota?: number;
+  remainingQuota?: number;
+  reason?: string;
+  recommendationInfo?: {
+    additionalTravel?: number;
+    travelKeyMatch?: boolean;
+  };
 }
 
 export interface OFSBookingOptionsArea {
-    label: string;
-    name?: string;
-    bucket?: string;
-    timeZone?: string;
-    timeZoneDiff?: number;
-    averageBucketTravel?: number;
-    averageTravelKeyTravel?: number;
-    timeSlots: OFSBookingOptionsTimeSlot[];
-    reason?: string;
+  label: string;
+  name?: string;
+  bucket?: string;
+  timeZone?: string;
+  timeZoneDiff?: number;
+  averageBucketTravel?: number;
+  averageTravelKeyTravel?: number;
+  timeSlots: OFSBookingOptionsTimeSlot[];
+  reason?: string;
 }
 
 export interface OFSBookingOptionsDate {
-    date: string;
-    areas: OFSBookingOptionsArea[];
+  date: string;
+  areas: OFSBookingOptionsArea[];
 }
 
 export interface OFSGetActivityBookingOptionsData {
-    actualAtTime?: string;
-    duration?: number;
-    travelTime?: number;
-    workZone?: string;
-    categories?: string[];
-    dates: OFSBookingOptionsDate[];
-    timeSlotsDictionary?: OFSTimeSlotDictionary[];
+  actualAtTime?: string;
+  duration?: number;
+  travelTime?: number;
+  workZone?: string;
+  categories?: string[];
+  dates: OFSBookingOptionsDate[];
+  timeSlotsDictionary?: OFSTimeSlotDictionary[];
 }
 
 export class OFSGetActivityBookingOptionsResponse extends OFSResponse {
-    data: OFSGetActivityBookingOptionsData = {
-        dates: [],
-    };
+  data: OFSGetActivityBookingOptionsData = {
+    dates: [],
+  };
 }

--- a/test/general/meta.test.ts
+++ b/test/general/meta.test.ts
@@ -1,7 +1,7 @@
 import {
-    OFSCredentials,
-    OFSPropertyDetails,
-    OFSPropertyDetailsResponse,
+  OFSCredentials,
+  OFSPropertyDetails,
+  OFSPropertyDetailsResponse,
 } from "../../src/model";
 import { OFS } from "../../src/OFS";
 import { getTestCredentials } from "../test_credentials";
@@ -15,301 +15,408 @@ var myProxy: OFS;
 var testConfig: any;
 
 interface MetaTestConfiguration {
-    numberOfProperties: number;
-    numberOfResourceProperties: number;
-    numberOfTimeslots: number;
+  numberOfProperties: number;
+  numberOfResourceProperties: number;
+  numberOfTimeslots: number;
 }
 const TEST_CONFIG: Map<string, MetaTestConfiguration> = new Map<string, any>();
 TEST_CONFIG.set("23.11", {
-    numberOfProperties: 464,
-    numberOfResourceProperties: 34,
-    numberOfTimeslots: 9,
+  numberOfProperties: 464,
+  numberOfResourceProperties: 34,
+  numberOfTimeslots: 9,
 });
 TEST_CONFIG.set("25A", {
-    numberOfProperties: 464,
-    numberOfResourceProperties: 44,
-    numberOfTimeslots: 9,
+  numberOfProperties: 464,
+  numberOfResourceProperties: 44,
+  numberOfTimeslots: 9,
 });
 // Setup info
 beforeAll(() => {
-    const credentials = getTestCredentials();
-    myProxy = new OFS(credentials);
-    if ("instance" in credentials) {
-        expect(myProxy.instance).toBe(credentials.instance);
-    } else {
-        expect(myProxy.baseURL).toBe(myProxy.baseURL);
-    }
-    var default_version: string = test_info.ofsVersion;
-    testConfig = TEST_CONFIG.get(default_version); // TODO: Store in jest config
+  const credentials = getTestCredentials();
+  myProxy = new OFS(credentials);
+  if ("instance" in credentials) {
+    expect(myProxy.instance).toBe(credentials.instance);
+  } else {
+    expect(myProxy.baseURL).toBe(myProxy.baseURL);
+  }
+  var default_version: string = test_info.ofsVersion;
+  testConfig = TEST_CONFIG.get(default_version); // TODO: Store in jest config
 });
 
 // Teardown info
 var activityList: number[] = [];
 afterAll(() => {
-    activityList.forEach(async (aid) => {
-        await myProxy.deleteActivity(aid);
-    });
+  activityList.forEach(async (aid) => {
+    await myProxy.deleteActivity(aid);
+  });
 });
 
 test("Get Properties, default values", async () => {
-    var result = await myProxy.getProperties();
-    try {
-        expect(result.status).toBe(200);
-        expect(result.data.items.length).toBe(100);
-        expect(result.data.totalResults).toBeGreaterThan(100);
-        expect(result.data.totalResults).toBeGreaterThanOrEqual(
-            testConfig.numberOfProperties
-        );
-        expect(result.data.offset).toBe(0);
-        expect(result.data.limit).toBe(100);
-    } catch (error) {
-        console.error(result);
-        throw error;
-    }
+  var result = await myProxy.getProperties();
+  try {
+    expect(result.status).toBe(200);
+    expect(result.data.items.length).toBe(100);
+    expect(result.data.totalResults).toBeGreaterThan(100);
+    expect(result.data.totalResults).toBeGreaterThanOrEqual(
+      testConfig.numberOfProperties
+    );
+    expect(result.data.offset).toBe(0);
+    expect(result.data.limit).toBe(100);
+  } catch (error) {
+    console.error(result);
+    throw error;
+  }
 });
 
 test("Get Properties, with offset", async () => {
-    let offset = faker.number.int({
-        min: 0,
-        max: testConfig.numberOfProperties - 100,
-    });
-    var result = await myProxy.getProperties({ offset: offset });
-    try {
-        expect(result.status).toBe(200);
-        expect(result.data.items.length).toBe(100);
-        expect(result.data.totalResults).toBeGreaterThanOrEqual(
-            testConfig.numberOfProperties
-        );
-        expect(result.data.offset).toBe(offset);
-        expect(result.data.limit).toBe(100);
-    } catch (error) {
-        console.error(result);
-        throw error;
-    }
+  let offset = faker.number.int({
+    min: 0,
+    max: testConfig.numberOfProperties - 100,
+  });
+  var result = await myProxy.getProperties({ offset: offset });
+  try {
+    expect(result.status).toBe(200);
+    expect(result.data.items.length).toBe(100);
+    expect(result.data.totalResults).toBeGreaterThanOrEqual(
+      testConfig.numberOfProperties
+    );
+    expect(result.data.offset).toBe(offset);
+    expect(result.data.limit).toBe(100);
+  } catch (error) {
+    console.error(result);
+    throw error;
+  }
 });
 
 test("Get Properties, with limit", async () => {
-    let limit = faker.number.int({ min: 10, max: 100 });
-    var result = await myProxy.getProperties({ limit: limit });
-    try {
-        expect(result.status).toBe(200);
-        expect(result.data.items.length).toBe(limit);
-        expect(result.data.totalResults).toBeGreaterThanOrEqual(
-            testConfig.numberOfProperties
-        );
-        expect(result.data.offset).toBe(0);
-        expect(result.data.limit).toBe(limit);
-    } catch (error) {
-        console.error(result);
-        throw error;
-    }
+  let limit = faker.number.int({ min: 10, max: 100 });
+  var result = await myProxy.getProperties({ limit: limit });
+  try {
+    expect(result.status).toBe(200);
+    expect(result.data.items.length).toBe(limit);
+    expect(result.data.totalResults).toBeGreaterThanOrEqual(
+      testConfig.numberOfProperties
+    );
+    expect(result.data.offset).toBe(0);
+    expect(result.data.limit).toBe(limit);
+  } catch (error) {
+    console.error(result);
+    throw error;
+  }
 });
 
 test("Get Properties, with offset and limit", async () => {
-    let offset = faker.number.int({
-        min: 0,
-        max: testConfig.numberOfProperties - 100,
-    });
-    let limit = faker.number.int({ min: 10, max: 100 });
-    var result = await myProxy.getProperties({ offset: offset, limit: limit });
-    try {
-        expect(result.status).toBe(200);
-        expect(result.data.items.length).toBe(limit);
-        expect(result.data.totalResults).toBeGreaterThanOrEqual(
-            testConfig.numberOfProperties
-        );
-        expect(result.data.offset).toBe(offset);
-        expect(result.data.limit).toBe(limit);
-    } catch (error) {
-        console.error(result);
-        throw error;
-    }
+  let offset = faker.number.int({
+    min: 0,
+    max: testConfig.numberOfProperties - 100,
+  });
+  let limit = faker.number.int({ min: 10, max: 100 });
+  var result = await myProxy.getProperties({ offset: offset, limit: limit });
+  try {
+    expect(result.status).toBe(200);
+    expect(result.data.items.length).toBe(limit);
+    expect(result.data.totalResults).toBeGreaterThanOrEqual(
+      testConfig.numberOfProperties
+    );
+    expect(result.data.offset).toBe(offset);
+    expect(result.data.limit).toBe(limit);
+  } catch (error) {
+    console.error(result);
+    throw error;
+  }
 });
 
 test("Get Properties, with entity", async () => {
-    var result = await myProxy.getProperties({ entity: "resource" });
-    try {
-        expect(result.status).toBe(200);
-        expect(result.data.items.length).toBeGreaterThan(0);
-        expect(result.data.totalResults).toBeGreaterThan(0);
-        expect(result.data.offset).toBe(0);
-        expect(result.data.limit).toBe(100);
-        result.data.items.forEach((element) => {
-            expect(element.entity).toBe("resource");
-        });
-    } catch (error) {
-        console.error(result);
-        throw error;
-    }
+  var result = await myProxy.getProperties({ entity: "resource" });
+  try {
+    expect(result.status).toBe(200);
+    expect(result.data.items.length).toBeGreaterThan(0);
+    expect(result.data.totalResults).toBeGreaterThan(0);
+    expect(result.data.offset).toBe(0);
+    expect(result.data.limit).toBe(100);
+    result.data.items.forEach((element) => {
+      expect(element.entity).toBe("resource");
+    });
+  } catch (error) {
+    console.error(result);
+    throw error;
+  }
 });
 
 test("Get Valid Field Details", async () => {
-    var result = await myProxy.getPropertyDetails("date");
-    expect(result.status).toBe(200);
-    expect(result.data.name).toBe("Date");
-    expect(result.data.type).toBe("field");
-    expect(result.data.entity).toBe("activity");
-    result.data.translations?.forEach((element) => {
-        if (element.languageISO == "en-US") {
-            expect(element.name).toBe("Date");
-            expect(element.language).toBe("en");
-        }
-    });
+  var result = await myProxy.getPropertyDetails("date");
+  expect(result.status).toBe(200);
+  expect(result.data.name).toBe("Date");
+  expect(result.data.type).toBe("field");
+  expect(result.data.entity).toBe("activity");
+  result.data.translations?.forEach((element) => {
+    if (element.languageISO == "en-US") {
+      expect(element.name).toBe("Date");
+      expect(element.language).toBe("en");
+    }
+  });
 });
 
 test("Get Valid Property Details", async () => {
-    var result = await myProxy.getPropertyDetails("DISPATCHER_COMMENTS");
-    expect(result.status).toBe(200);
-    expect(result.data.name).toBe("Dispatcher Comments");
-    expect(result.data.type).toBe("string");
-    expect(result.data.entity).toBe("activity");
-    result.data.translations?.forEach((element) => {
-        if (element.languageISO == "en-US") {
-            expect(element.name).toBe("Dispatcher Comments");
-            expect(element.language).toBe("en");
-        }
-    });
-    console.log(result);
-    console.log(result.data.translations?.slice(0, 1));
+  var result = await myProxy.getPropertyDetails("DISPATCHER_COMMENTS");
+  expect(result.status).toBe(200);
+  expect(result.data.name).toBe("Dispatcher Comments");
+  expect(result.data.type).toBe("string");
+  expect(result.data.entity).toBe("activity");
+  result.data.translations?.forEach((element) => {
+    if (element.languageISO == "en-US") {
+      expect(element.name).toBe("Dispatcher Comments");
+      expect(element.language).toBe("en");
+    }
+  });
+  console.log(result);
+  console.log(result.data.translations?.slice(0, 1));
+});
+
+test("Get Forms, default values", async () => {
+  const result = await myProxy.getForms();
+
+  if (result.status === 403) {
+    expect(result.data).toHaveProperty("detail");
+    return;
+  }
+
+  expect(result.status).toBe(200);
+  expect(Array.isArray(result.data.items)).toBe(true);
+  expect(result.data.items.length).toBeGreaterThan(0);
+  expect(result.data.totalResults).toBeGreaterThan(0);
+  expect(result.data.offset).toBe(0);
+  expect(result.data.limit).toBe(100);
+});
+
+test("Get Forms, with offset, limit, and language", async () => {
+  const result = await myProxy.getForms({
+    offset: 0,
+    limit: 1,
+    language: "en",
+  });
+
+  expect(result.url.searchParams.get("offset")).toBe("0");
+  expect(result.url.searchParams.get("limit")).toBe("1");
+  expect(result.url.searchParams.get("language")).toBe("en");
+
+  if (result.status === 403) {
+    expect(result.data).toHaveProperty("detail");
+    return;
+  }
+
+  expect(result.status).toBe(200);
+  expect(result.data.items.length).toBeLessThanOrEqual(1);
+  if (result.data.items.length > 0) {
+    expect(typeof result.data.items[0].label).toBe("string");
+    expect(typeof result.data.items[0].name).toBe("string");
+  }
+});
+
+test("Get All Forms", async () => {
+  const firstPage = await myProxy.getForms({ offset: 0, limit: 1 });
+
+  if (firstPage.status === 403) {
+    expect(firstPage.data).toHaveProperty("detail");
+    return;
+  }
+
+  expect(firstPage.status).toBe(200);
+
+  const result = await myProxy.getAllForms({ language: "en" }, 1);
+
+  if ("status" in result && result.status === 403) {
+    expect(result.data).toHaveProperty("detail");
+    return;
+  }
+
+  expect(result.totalResults).toBe(result.items.length);
+  expect(result.items.length).toBeGreaterThan(0);
+  expect(result.offset).toBe(0);
+  expect(result.items[0].label).toBe(firstPage.data.items[0].label);
+});
+
+test("Get Valid Form Details", async () => {
+  const formsResult = await myProxy.getForms({
+    limit: 1,
+    language: "en",
+  });
+
+  expect(formsResult.url.searchParams.get("language")).toBe("en");
+
+  if (formsResult.status === 403) {
+    expect(formsResult.data).toHaveProperty("detail");
+    return;
+  }
+
+  expect(formsResult.status).toBe(200);
+  expect(formsResult.data.items.length).toBeGreaterThan(0);
+
+  const formLabel = formsResult.data.items[0].label;
+  const result = await myProxy.getFormDetails(formLabel, { language: "en" });
+
+  expect(result.url.searchParams.get("language")).toBe("en");
+
+  if (result.status === 403) {
+    expect(result.data).toHaveProperty("detail");
+    return;
+  }
+
+  expect(result.status).toBe(200);
+  expect(result.data.label).toBe(formLabel);
+  expect(typeof result.data.name).toBe("string");
+  expect(result.data.name.length).toBeGreaterThan(0);
+  expect(result.data.content).toBeDefined();
 });
 
 test("Get Invalid Property Details", async () => {
-    var result = await myProxy.getPropertyDetails("invalid");
-    expect(result.status).toBe(404);
+  var result = await myProxy.getPropertyDetails("invalid");
+  expect(result.status).toBe(404);
+});
+
+test("Get Invalid Form Details", async () => {
+  var result = await myProxy.getFormDetails("invalid");
+  expect([403, 404]).toContain(result.status);
 });
 
 test("Create custom property", async () => {
-    var propertyLabel = `TEST_${faker.word.noun()}_${faker.number.int()}`;
-    var propertyData = {
+  var propertyLabel = `TEST_${faker.word.noun()}_${faker.number.int()}`;
+  var propertyData = {
+    name: "Test Property",
+    label: propertyLabel,
+    type: "string",
+    entity: "activity",
+    gui: "text",
+    translations: [
+      {
+        language: "en",
         name: "Test Property",
-        label: propertyLabel,
-        type: "string",
-        entity: "activity",
-        gui: "text",
-        translations: [
-            {
-                language: "en",
-                name: "Test Property",
-                languageISO: "en-US",
-            },
-        ],
-    };
-    var result = await myProxy.createReplaceProperty(propertyData);
-    try {
-        expect(result.status).toBe(201);
-    } catch (error) {
-        console.log(result);
-        throw error;
-    }
-    expect(result.data.name).toBe(propertyData.name);
-    expect(result.data.type).toBe(propertyData.type);
-    expect(result.data.entity).toBe(propertyData.entity);
-    expect(result.data.gui).toBe(propertyData.gui);
-    //expect(result.data.translations).toStrictEqual(propertyData.translations);
+        languageISO: "en-US",
+      },
+    ],
+  };
+  var result = await myProxy.createReplaceProperty(propertyData);
+  try {
+    expect(result.status).toBe(201);
+  } catch (error) {
+    console.log(result);
+    throw error;
+  }
+  expect(result.data.name).toBe(propertyData.name);
+  expect(result.data.type).toBe(propertyData.type);
+  expect(result.data.entity).toBe(propertyData.entity);
+  expect(result.data.gui).toBe(propertyData.gui);
+  //expect(result.data.translations).toStrictEqual(propertyData.translations);
 });
 
 test("Replace custom property", async () => {
-    var propertyLabel = `TEST_${faker.word.noun()}_${faker.number.int()}`;
-    var propertyData = {
+  var propertyLabel = `TEST_${faker.word.noun()}_${faker.number.int()}`;
+  var propertyData = {
+    name: "Test Property ORIGINAL",
+    label: propertyLabel,
+    type: "string",
+    entity: "activity",
+    gui: "text",
+    translations: [
+      {
+        language: "en",
         name: "Test Property ORIGINAL",
-        label: propertyLabel,
-        type: "string",
-        entity: "activity",
-        gui: "text",
-        translations: [
-            {
-                language: "en",
-                name: "Test Property ORIGINAL",
-                languageISO: "en-US",
-            },
-        ],
-    };
-    var result = await myProxy.createReplaceProperty(propertyData);
-    try {
-        expect(result.status).toBe(201);
-    } catch (error) {
-        console.log(result);
-        throw error;
-    }
-    expect(result.data.name).toBe(propertyData.name);
-    propertyData.name = "Test Property CHANGED";
-    propertyData.type = "string";
-    propertyData.translations[0].name = "Test Property CHANGED";
-    var result2 = await myProxy.createReplaceProperty(propertyData);
-    try {
-        expect(result2.status).toBe(200);
-        expect(result2.data.name).toBe(propertyData.name);
-    } catch (error) {
-        console.log(propertyData);
-        console.log(result2);
-        throw error;
-    }
+        languageISO: "en-US",
+      },
+    ],
+  };
+  var result = await myProxy.createReplaceProperty(propertyData);
+  try {
+    expect(result.status).toBe(201);
+  } catch (error) {
+    console.log(result);
+    throw error;
+  }
+  expect(result.data.name).toBe(propertyData.name);
+  propertyData.name = "Test Property CHANGED";
+  propertyData.type = "string";
+  propertyData.translations[0].name = "Test Property CHANGED";
+  var result2 = await myProxy.createReplaceProperty(propertyData);
+  try {
+    expect(result2.status).toBe(200);
+    expect(result2.data.name).toBe(propertyData.name);
+  } catch (error) {
+    console.log(propertyData);
+    console.log(result2);
+    throw error;
+  }
 });
 
 test("Update custom property", async () => {
-    var propertyLabel = `TEST_${faker.word.noun()}_${faker.number.int()}`;
-    var propertyData: OFSPropertyDetails = {
+  var propertyLabel = `TEST_${faker.word.noun()}_${faker.number.int()}`;
+  var propertyData: OFSPropertyDetails = {
+    name: "Test Property ORIGINAL",
+    label: propertyLabel,
+    type: "string",
+    entity: "activity",
+    gui: "text",
+    translations: [
+      {
+        language: "en",
         name: "Test Property ORIGINAL",
-        label: propertyLabel,
-        type: "string",
-        entity: "activity",
-        gui: "text",
-        translations: [
-            {
-                language: "en",
-                name: "Test Property ORIGINAL",
-                languageISO: "en-US",
-            },
-        ],
-    };
-    var result: OFSPropertyDetailsResponse =
-        await myProxy.createReplaceProperty(propertyData);
-    try {
-        expect(result.status).toBe(201);
-    } catch (error) {
-        console.log(result);
-        throw error;
-    }
-    expect(result.data.name).toBe(propertyData.name);
-    expect(result.data.cloneFlag).toBe(false);
-    var newPropertyData = {
-        label: propertyLabel,
-        cloneFlag: true,
-    };
-    var result2 = await myProxy.updateProperty(newPropertyData);
-    try {
-        expect(result2.status).toBe(200);
-        expect(result2.data.name).toBe(propertyData.name);
-        expect(result2.data.type).toBe(propertyData.type);
-        expect(result2.data.cloneFlag).toBe(true);
-    } catch (error) {
-        console.log(propertyData);
-        console.log(result2);
-        throw error;
-    }
+        languageISO: "en-US",
+      },
+    ],
+  };
+  var result: OFSPropertyDetailsResponse = await myProxy.createReplaceProperty(
+    propertyData
+  );
+  try {
+    expect(result.status).toBe(201);
+  } catch (error) {
+    console.log(result);
+    throw error;
+  }
+  expect(result.data.name).toBe(propertyData.name);
+  expect(result.data.cloneFlag).toBe(false);
+  var newPropertyData = {
+    label: propertyLabel,
+    cloneFlag: true,
+  };
+  var result2 = await myProxy.updateProperty(newPropertyData);
+  try {
+    expect(result2.status).toBe(200);
+    expect(result2.data.name).toBe(propertyData.name);
+    expect(result2.data.type).toBe(propertyData.type);
+    expect(result2.data.cloneFlag).toBe(true);
+  } catch (error) {
+    console.log(propertyData);
+    console.log(result2);
+    throw error;
+  }
 });
 
 test("Get a list of configured timeslots", async () => {
-    var result = await myProxy.getTimeslots();
-    try {
-        expect(result.status).toBe(200);
-        expect(result.status).toBe(200);
+  var result = await myProxy.getTimeslots();
+  try {
+    expect(result.status).toBe(200);
+    expect(result.status).toBe(200);
     expect(result.data.items.length).toBeGreaterThan(0);
-        expect(result.data.offset).toBe(0);
-        expect(result.data.limit).toBe(100);
-    } catch (error) {
-        console.error(result);
-        throw error;
-    }
+    expect(result.data.offset).toBe(0);
+    expect(result.data.limit).toBe(100);
+  } catch (error) {
+    console.error(result);
+    throw error;
+  }
 });
 
 test("Get Link Templates", async () => {
-    var result = await myProxy.getLinkTemplates();
-    expect(result.status).toBe(200);
-    expect(result.data.items.length).toBeGreaterThan(0);
-    expect(Array.isArray(result.data.items)).toBe(true);
-    // Optionally log the first template for inspection
-    if (result.data.items.length > 0) {
-        console.log("First Link Template:", result.data.items[0]);
-    }
+  var result = await myProxy.getLinkTemplates();
+  if (result.status === 403) {
+    expect(result.data).toHaveProperty("detail");
+    return;
+  }
+
+  expect(result.status).toBe(200);
+  expect(result.data.items.length).toBeGreaterThan(0);
+  expect(Array.isArray(result.data.items)).toBe(true);
+  // Optionally log the first template for inspection
+  if (result.data.items.length > 0) {
+    console.log("First Link Template:", result.data.items[0]);
+  }
 });


### PR DESCRIPTION
## Summary
- add `getForms`, `getAllForms`, and `getFormDetails` for OFS metadata forms endpoints
- add model types and metadata integration coverage for forms listing, pagination, and details
- document the new methods and include the version bumps to `1.29.0` and `1.30.0`

## Testing
- `npm run build`
- `npm test -- --runInBand test/general/meta.test.ts`

Closes #81